### PR TITLE
Fix Docker command arguments format for environment variables

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,6 +74,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=long
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
       
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -226,9 +226,21 @@ The `build-local.sh` script provides a lightweight local development build pipel
 
 #### CI/CD
 
-For CI/CD, we use GitHub Actions to build and publish the Docker image to GitHub Container Registry. The workflow is defined in `.github/workflows/build-and-publish.yml`.
+For CI/CD, we use GitHub Actions to build and publish the Docker image to GitHub Container Registry. The workflow is defined in `.github/workflows/ci-cd.yml`.
 
 Our approach focuses on Continuous Delivery rather than full CI/CD, as we're not running actual tests against the Atlassian API. See `docs/ci-cd-plan.md` for more details on our CI/CD strategy and future plans.
+
+#### Docker Image Tags
+
+We use a consistent tagging strategy for Docker images:
+
+- **jira-cloud:local**: Local development build (not pushed to registry)
+- **ghcr.io/aaronsb/jira-cloud:latest**: Most recent stable build from main branch
+- **ghcr.io/aaronsb/jira-cloud:main**: Same as latest
+- **ghcr.io/aaronsb/jira-cloud:sha-[commit-hash]**: Specific commit version
+- **ghcr.io/aaronsb/jira-cloud:v[version]**: Specific semantic version release
+
+For most users, the `:latest` tag is recommended for production use.
 
 ## Installation
 
@@ -241,11 +253,13 @@ For VSCode, the configuration goes in:
 - macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
 - Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
 
-Example configuration:
+Example configurations:
+
+#### Using Local Build
 ```json
 {
   "mcpServers": {
-    "team1": {
+    "jira-cloud": {
       "command": "node",
       "args": ["${userHome}/path/to/jira-cloud/build/index.js"],
       "env": {
@@ -253,14 +267,72 @@ Example configuration:
         "JIRA_EMAIL": "your-email",
         "JIRA_HOST": "your-team.atlassian.net"
       }
-    },
-    "team2": {
-      "command": "node",
-      "args": ["${userHome}/path/to/jira-cloud/build/index.js"],
+    }
+  }
+}
+```
+
+#### Using Docker Container (Recommended)
+```json
+{
+  "mcpServers": {
+    "jira-cloud": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/aaronsb/jira-cloud:latest"
+      ],
       "env": {
         "JIRA_API_TOKEN": "your-api-token",
         "JIRA_EMAIL": "your-email",
-        "JIRA_HOST": "another-team.atlassian.net"
+        "JIRA_HOST": "your-team.atlassian.net"
+      }
+    }
+  }
+}
+```
+
+#### Multiple Jira Instances
+```json
+{
+  "mcpServers": {
+    "team1-jira": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/aaronsb/jira-cloud:latest"
+      ],
+      "env": {
+        "JIRA_API_TOKEN": "your-api-token",
+        "JIRA_EMAIL": "your-email",
+        "JIRA_HOST": "team1.atlassian.net"
+      }
+    },
+    "team2-jira": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
+        "ghcr.io/aaronsb/jira-cloud:latest"
+      ],
+      "env": {
+        "JIRA_API_TOKEN": "your-api-token",
+        "JIRA_EMAIL": "your-email",
+        "JIRA_HOST": "team2.atlassian.net"
       }
     }
   }

--- a/docs/ci-cd-plan.md
+++ b/docs/ci-cd-plan.md
@@ -102,6 +102,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=long
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
       
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -124,6 +125,30 @@ jobs:
           min-versions-to-keep: 10
           delete-only-untagged-versions: true
 ```
+
+## Docker Image Tagging Strategy
+
+Our Docker image tagging strategy provides clear identification of image versions while supporting both development and production use cases:
+
+### Local Development
+- **jira-cloud:local**: Created by the `build-local.sh` script for local development and testing
+  - This tag is only available locally and is not pushed to the GitHub Container Registry
+  - Provides a clear distinction between local development builds and CI/CD builds
+
+### CI/CD Builds (GitHub Container Registry)
+- **ghcr.io/aaronsb/jira-cloud:latest**: Points to the most recent stable build from the main branch
+  - Automatically updated when changes are pushed to the main branch
+  - Recommended for production use when you want to always use the most recent stable version
+- **ghcr.io/aaronsb/jira-cloud:main**: Also points to the most recent build from the main branch
+  - Functionally equivalent to the latest tag
+- **ghcr.io/aaronsb/jira-cloud:sha-[commit-hash]**: Points to a specific commit
+  - Provides immutable references to exact versions
+  - Recommended when you need version stability and want to control when updates occur
+- **ghcr.io/aaronsb/jira-cloud:v[version]**: Points to a specific semantic version release
+  - Created when a version tag is pushed to the repository
+  - Follows semantic versioning conventions (e.g., v1.0.0)
+
+This strategy allows users to choose between stability (using specific SHA or version tags) and receiving automatic updates (using the latest tag).
 
 ## Future Enhancements
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,9 +27,28 @@ npm run build
 
 ### Docker Installation
 
-Pull the container:
+You can use either the locally built Docker image or the one from GitHub Container Registry (ghcr.io):
+
+#### Local Development Image
+Build and use the local development image:
 ```bash
+# Build the local image
+./scripts/build-local.sh
+
+# This creates jira-cloud:local tag
+```
+
+#### GitHub Container Registry Image
+Pull the container from GitHub Container Registry:
+```bash
+# Pull the latest stable version (from main branch)
 docker pull ghcr.io/aaronsb/jira-cloud:latest
+
+# Or pull a specific version by commit SHA
+docker pull ghcr.io/aaronsb/jira-cloud:sha-<commit-hash>
+
+# Or pull by branch name
+docker pull ghcr.io/aaronsb/jira-cloud:main
 ```
 
 ## Configuration
@@ -76,7 +95,20 @@ npm run dev
 
 ### Docker Usage
 
-Run with environment variables:
+Run with environment variables (using either local or ghcr.io image):
+
+#### Using Local Development Image:
+```bash
+docker run -i \
+  -e JIRA_API_TOKEN=your_api_token \
+  -e JIRA_EMAIL=your_email \
+  -e JIRA_HOST=your-instance.atlassian.net \
+  -v /path/to/config:/app/config \
+  -v /path/to/logs:/app/logs \
+  jira-cloud:local
+```
+
+#### Using GitHub Container Registry Image:
 ```bash
 docker run -i \
   -e JIRA_API_TOKEN=your_api_token \

--- a/llms-install.md
+++ b/llms-install.md
@@ -17,12 +17,9 @@ The recommended way to install this MCP server is using the Docker container fro
         "run",
         "-i",
         "--rm",
-        "-e",
-        "JIRA_EMAIL",
-        "-e",
-        "JIRA_HOST",
-        "-e",
-        "JIRA_API_TOKEN",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
         "ghcr.io/aaronsb/jira-cloud:latest"
       ],
       "env": {
@@ -90,12 +87,9 @@ If the user needs to connect to multiple Jira instances, use a configuration lik
         "run",
         "-i",
         "--rm",
-        "-e",
-        "JIRA_EMAIL",
-        "-e",
-        "JIRA_HOST",
-        "-e",
-        "JIRA_API_TOKEN",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
         "ghcr.io/aaronsb/jira-cloud:latest"
       ],
       "env": {
@@ -112,12 +106,9 @@ If the user needs to connect to multiple Jira instances, use a configuration lik
         "run",
         "-i",
         "--rm",
-        "-e",
-        "JIRA_EMAIL",
-        "-e",
-        "JIRA_HOST",
-        "-e",
-        "JIRA_API_TOKEN",
+        "-e", "JIRA_EMAIL",
+        "-e", "JIRA_HOST",
+        "-e", "JIRA_API_TOKEN",
         "ghcr.io/aaronsb/jira-cloud:latest"
       ],
       "env": {

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -44,6 +44,7 @@ check_log_size() {
             echo "  • tail -n 20 $log_file     (view last 20 lines)"
             echo "  • less $log_file           (scroll through file)"
             echo "  • grep 'error' $log_file   (search for specific terms)"
+            echo "  • use pageless mode with tools when viewing files"
         fi
     fi
 }


### PR DESCRIPTION
This PR fixes the Docker command arguments format for environment variables in the MCP server configuration and updates all relevant documentation to reflect the correct format. This resolves the issue with the Jira Cloud MCP server in Claude Desktop where environment variables were not being properly passed to the Docker container.