### PR TITLE
Add issue linking functionality and link types resource

### DIFF
--- a/src/handlers/issue-handlers.ts
+++ b/src/handlers/issue-handlers.ts
@@ -372,24 +372,19 @@ async function handleCommentIssue(jiraClient: JiraClient, args: ManageJiraIssueA
   };
 }
 
-async function handleLinkIssue(_jiraClient: JiraClient, _args: ManageJiraIssueArgs) {
-  // Note: This is a placeholder. The current JiraClient doesn't have a linkIssues method.
-  // You would need to implement this in the JiraClient class.
-  throw new McpError(
-    ErrorCode.InternalError,
-    'Link issue operation is not yet implemented'
-  );
-
-  // When implemented, it would look something like this:
-  /*
-  await _jiraClient.linkIssues(
-    _args.issueKey!,
-    _args.linkedIssueKey!,
-    _args.linkType!
+async function handleLinkIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs) {
+  console.error(`Linking issue ${args.issueKey} to ${args.linkedIssueKey} with type ${args.linkType}`);
+  
+  // Link the issues
+  await jiraClient.linkIssues(
+    args.issueKey!,
+    args.linkedIssueKey!,
+    args.linkType!,
+    args.comment
   );
 
   // Get the updated issue to return
-  const updatedIssue = await _jiraClient.getIssue(_args.issueKey!, false, false);
+  const updatedIssue = await jiraClient.getIssue(args.issueKey!, false, false);
   const formattedResponse = IssueFormatter.formatIssue(updatedIssue);
 
   return {
@@ -400,7 +395,6 @@ async function handleLinkIssue(_jiraClient: JiraClient, _args: ManageJiraIssueAr
       },
     ],
   };
-  */
 }
 
 // Main handler function

--- a/src/handlers/resource-handlers.ts
+++ b/src/handlers/resource-handlers.ts
@@ -26,6 +26,12 @@ export function setupResourceHandlers(jiraClient: JiraClient) {
             name: 'Project Distribution',
             mimeType: 'application/json',
             description: 'Distribution of projects by type and status'
+          },
+          {
+            uri: 'jira://issue-link-types',
+            name: 'Issue Link Types',
+            mimeType: 'application/json',
+            description: 'List of all available issue link types in the Jira instance'
           }
         ]
       };
@@ -67,6 +73,10 @@ export function setupResourceHandlers(jiraClient: JiraClient) {
         
         if (uri === 'jira://projects/distribution') {
           return await getProjectDistribution(jiraClient);
+        }
+        
+        if (uri === 'jira://issue-link-types') {
+          return await getIssueLinkTypes(jiraClient);
         }
         
         // Handle resource templates
@@ -290,6 +300,45 @@ async function getBoardOverview(jiraClient: JiraClient, boardId: number) {
     };
   } catch (error) {
     console.error(`Error getting board overview for ${boardId}:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Gets all available issue link types
+ */
+async function getIssueLinkTypes(jiraClient: JiraClient) {
+  try {
+    // Get all issue link types
+    const linkTypes = await jiraClient.getIssueLinkTypes();
+    
+    // Format the response with usage examples
+    const formattedLinkTypes = linkTypes.map(linkType => ({
+      id: linkType.id,
+      name: linkType.name,
+      inward: linkType.inward,
+      outward: linkType.outward,
+      usage: {
+        description: `Use this link type to establish a "${linkType.outward}" relationship from one issue to another.`,
+        example: `When issue A ${linkType.outward} issue B, then issue B ${linkType.inward} issue A.`
+      }
+    }));
+    
+    return {
+      contents: [
+        {
+          uri: 'jira://issue-link-types',
+          mimeType: 'application/json',
+          text: JSON.stringify({
+            linkTypes: formattedLinkTypes,
+            count: formattedLinkTypes.length,
+            timestamp: new Date().toISOString()
+          }, null, 2)
+        }
+      ]
+    };
+  } catch (error) {
+    console.error('Error getting issue link types:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Overview
This PR implements issue linking functionality for the Jira Cloud MCP server, allowing users to create and view links between issues.

## Changes
- Added `linkIssues` and `getIssueLinkTypes` methods to the JiraClient class
- Updated the issue handlers to implement the link operation
- Added a resource for issue link types at `jira://issue-link-types`

## Testing
Tested with the MBP project by:
- Retrieving all available link types
- Creating various types of links between issues (implements, relates to, blocks)
- Verifying that the relationships are bidirectional and show correctly from both sides

## Documentation
The implementation follows the design outlined in the issue-relations-implementation.md document.