### PR TITLE
docs: update README and llms-install for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ Generate an API token at [Atlassian Account Settings](https://id.atlassian.com/m
 
 | Tool | Description |
 |------|-------------|
-| `manage_jira_issue` | Get, create, update, transition, comment on, or link Jira issues |
+| `manage_jira_issue` | Get, create, update, delete, move, transition, comment on, or link Jira issues |
 | `manage_jira_filter` | Search for issues using JQL queries, or manage saved filters |
 | `manage_jira_project` | List projects or get project details including status counts |
 | `manage_jira_board` | List boards or get board details and configuration |
 | `manage_jira_sprint` | Manage sprints: create, start, close, and assign issues to sprints |
+| `queue_jira_operations` | Execute multiple operations in one call with result references and error strategies |
 
-Each tool accepts an `operation` parameter. Detailed documentation is available as MCP resources at `jira://tools/{tool_name}/documentation`.
+Each tool accepts an `operation` parameter (except `queue_jira_operations` which takes an `operations` array). Detailed documentation is available as MCP resources at `jira://tools/{tool_name}/documentation`.
 
 ## MCP Resources
 
@@ -52,6 +53,8 @@ Each tool accepts an `operation` parameter. Detailed documentation is available 
 | `jira://projects/{key}/overview` | Project overview with status counts |
 | `jira://boards/{id}/overview` | Board overview with sprint info |
 | `jira://issue-link-types` | Available issue link types |
+| `jira://custom-fields` | Custom field catalog (auto-discovered at startup) |
+| `jira://custom-fields/{project}/{issueType}` | Context-specific custom fields |
 | `jira://tools/{name}/documentation` | Tool documentation |
 
 ## License

--- a/llms-install.md
+++ b/llms-install.md
@@ -32,17 +32,20 @@ Add to MCP settings (no install required — uses npx):
 
 ## Tools
 
-The server exposes 5 tools, each with an `operation` parameter:
+The server exposes 6 tools:
 
 | Tool | Operations |
 |------|-----------|
-| `manage_jira_issue` | `get`, `create`, `update`, `transition`, `comment`, `link` |
+| `manage_jira_issue` | `get`, `create`, `update`, `delete`, `move`, `transition`, `comment`, `link` |
 | `manage_jira_filter` | `get`, `list`, `create`, `update`, `delete`, `execute_jql`, `execute_filter` |
 | `manage_jira_project` | `get`, `list` |
-| `manage_jira_board` | `get`, `list`, `get_configuration` |
+| `manage_jira_board` | `get`, `list` |
 | `manage_jira_sprint` | `get`, `list`, `create`, `update`, `delete`, `manage_issues` |
+| `queue_jira_operations` | Execute multiple operations in one call with result references (`$0.key`) and error strategies (`bail`/`continue`) |
 
-Each tool also has MCP resource documentation at `jira://tools/{tool_name}/documentation`.
+Each tool has MCP resource documentation at `jira://tools/{tool_name}/documentation`.
+
+Custom field discovery runs at startup — use `jira://custom-fields` to browse the catalog or `jira://custom-fields/{projectKey}/{issueType}` for context-specific fields.
 
 ## Multiple Instances
 


### PR DESCRIPTION
## Summary
- Add `queue_jira_operations` tool to README and llms-install
- Add `delete`/`move` operations to issue tool description
- Fix board tool ops (remove nonexistent `get_configuration`)
- Add custom-fields resources to both docs

Prep for v0.3.0 release.