### PR TITLE
feat: analyze_jira_issues — project metrics tool

### DIFF
--- a/docs/architecture/ADR-204-issue-analysis-tool.md
+++ b/docs/architecture/ADR-204-issue-analysis-tool.md
@@ -1,0 +1,164 @@
+# ADR-204: Issue Analysis Tool
+
+| Field | Value |
+|-------|-------|
+| Status | Proposed |
+| Domain | tools |
+| Created | 2026-03-06 |
+| Decides | How to provide deterministic computations over sets of Jira issues |
+
+## Context
+
+LLMs are unreliable at arithmetic. When a project manager asks "what are the total story points for this sprint?" or "which issues are overdue?", the model must fetch issues, extract fields, and compute — often getting it wrong. We need a tool that accepts a JQL query and returns pre-computed metrics so the LLM can report them directly.
+
+This is the "breadth analysis" complement to the existing focus view (`get`/`update` on single issues) and breadth traversal (`hierarchy`). Where hierarchy shows structure, analysis shows the numbers.
+
+### Design Principles (from ADR-200)
+
+- Tools should be action-oriented and composable
+- Reduce LLM cognitive load by doing the math server-side
+- Keep the interface simple; let JQL handle issue selection
+- Ground metrics in established PM methodologies so outputs use recognized terminology
+
+## Decision
+
+Add a new tool `analyze_jira_issues` that accepts a JQL query and returns computed metrics over the matching issue set. Metrics are grounded in Earned Value Management (EVM), Lean/Kanban flow metrics, and standard schedule analysis — using the accepted terminology so PMs recognize what they're looking at.
+
+### Metric Groups (v1)
+
+#### `points` — Earned Value (Story Points as value unit)
+
+From EVM (PMI PMBOK):
+- **Planned Value (PV)** — total story points in the set (what was committed)
+- **Earned Value (EV)** — story points on resolved issues (what was delivered)
+- **Remaining** — PV - EV
+- **Schedule Performance Index (SPI)** — EV / PV (1.0 = on track, < 1.0 = behind, > 1.0 = ahead)
+- **Breakdown by status category** — To Do / In Progress / Done point totals
+- **Unestimated count** — issues missing story points (estimation gap)
+
+#### `time` — Effort Tracking
+
+- **Original Estimate** — sum of `timeEstimate` across all issues
+- **By status category** — estimated effort remaining (To Do + In Progress) vs completed (Done)
+- **Unestimated count** — issues missing time estimates
+
+#### `schedule` — Date & Risk Analysis
+
+Standard schedule analysis:
+- **Date range** — earliest `startDate` to latest `dueDate` (project window)
+- **Overdue** — issues past `dueDate` that aren't resolved (count + keys)
+- **Slip (aggregate)** — total days past due across overdue issues
+- **Due soon** — issues due in next 7 / 14 / 30 days
+- **Concentration risk** — dates with unusually many items due (highlights bunching)
+- **No due date** — issues missing `dueDate` (schedule blind spots)
+
+#### `cycle` — Flow Metrics (Lean/Kanban)
+
+From Lean methodology:
+- **Lead time** — median and mean days from `created` to `resolutionDate` (for resolved issues)
+- **Throughput** — resolved issues per week over the set's date range
+- **Age** — for open issues: days since `created` (highlights stale work)
+- **Oldest open** — the N oldest unresolved issues (WIP risk)
+
+#### `distribution` — Composition
+
+- Issue count by **status**
+- Issue count by **assignee** (workload balance)
+- Issue count by **priority**
+- Issue count by **issue type**
+
+### Interface
+
+```typescript
+{
+  tool: "analyze_jira_issues",
+  args: {
+    jql: string,          // Required — selects the issue set
+    metrics?: string[],   // Optional — which metric groups to include
+                          // Default: all. Values: "points", "time", "schedule", "cycle", "distribution"
+    maxResults?: number   // Max issues to analyze (default 200)
+  }
+}
+```
+
+### Output Shape
+
+Markdown report with named sections. Numbers are pre-computed and labeled with their PM methodology origin. The LLM reads and relays — no arithmetic required.
+
+```markdown
+# Analysis: sprint = 42
+Analyzed 34 issues (as of Mar 6, 2026)
+
+## Points (Earned Value)
+| Metric | Value |
+|--------|-------|
+| Planned Value (PV) | 89 pts |
+| Earned Value (EV) | 42 pts |
+| Remaining | 47 pts |
+| SPI | 0.47 |
+| Unestimated | 5 issues |
+
+**By status:** To Do: 21 pts | In Progress: 26 pts | Done: 42 pts
+
+## Schedule
+**Window:** Feb 1 - Mar 15, 2026
+**Overdue:** 3 issues, 18 days total slip (AA-101, AA-205, AA-310)
+**Due next 7 days:** 8 issues
+**Due next 14 days:** 12 issues
+**Concentration:** Mar 9 has 5 issues due
+**No due date:** 4 issues
+
+## Cycle (Flow Metrics)
+**Lead time (resolved):** median 4.5 days, mean 6.2 days (12 issues)
+**Throughput:** 3.1 issues/week
+**Oldest open:** AA-98 (45 days), AA-112 (38 days), AA-150 (22 days)
+
+## Distribution
+**By status:** To Do: 14 | In Progress: 8 | Done: 12
+**By assignee:** Alice: 12 | Bob: 10 | Unassigned: 12
+**By priority:** High: 8 | Medium: 20 | Low: 6
+**By type:** Story: 20 | Bug: 8 | Task: 6
+```
+
+### Status Category Mapping
+
+Jira issues have a `statusCategory` (one of: `new`, `indeterminate`, `done`) that maps cleanly:
+- `new` → **To Do**
+- `indeterminate` → **In Progress**
+- `done` → **Done**
+
+This is more reliable than mapping status names (which vary per project). We'll need to add `statusCategory` to the fields we fetch.
+
+### What This Does NOT Do
+
+- Velocity prediction or forecasting (requires historical sprint-over-sprint data — future metric group)
+- Burndown/burnup visualization (text output only)
+- Cross-sprint comparison (single query scope; user can run multiple analyses)
+- Modify any issues (read-only tool)
+
+### Extensibility
+
+The `metrics` parameter and sectioned output make it straightforward to add metric groups later:
+- `velocity` — historical sprint completion rates
+- `links` — dependency graph density, blocking chain analysis
+- `labels` — tag-based categorization
+- `custom` — aggregation over discovered custom fields (ADR-201)
+
+Each new group is additive — no interface changes needed.
+
+## Alternatives Considered
+
+**A. New operation on `manage_jira_issue`** — Rejected. That tool is already the largest; adding analysis muddies its "operate on issues" purpose.
+
+**B. New operation on `manage_jira_filter`** — Rejected. Semantically close (JQL is there), but "filter" implies search/retrieval, not computation. Would confuse tool selection.
+
+**D. Auto-append summary to `execute_jql`** — Rejected. Always pays the cost, adds noise to simple searches, and can't be parameterized.
+
+## Consequences
+
+- New tool in the catalog (7th tool) — increases tool selection surface slightly
+- Reuses existing `issueFields` and `mapIssueFields` from JiraClient — minimal new API surface
+- Need to add `statusCategory` to fetched fields (for reliable To Do/In Progress/Done bucketing)
+- `maxResults` caps compute cost at 200 issues; warns if query matches more
+- Metrics use standard PM terminology (EVM, Lean) — outputs are recognizable to practitioners
+- All math is deterministic and server-side — LLM never does arithmetic

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -59,6 +59,10 @@
       "description": "Manage sprints and assign issues to sprints"
     },
     {
+      "name": "analyze_jira_issues",
+      "description": "Compute project metrics over a set of issues selected by JQL"
+    },
+    {
       "name": "queue_jira_operations",
       "description": "Execute multiple Jira operations in a single call"
     }

--- a/src/client/jira-client.ts
+++ b/src/client/jira-client.ts
@@ -130,6 +130,7 @@ export class JiraClient {
       assignee: fields?.assignee?.displayName || null,
       reporter: fields?.reporter?.displayName || '',
       status: fields?.status?.name || '',
+      statusCategory: fields?.status?.statusCategory?.key || 'unknown',
       resolution: fields?.resolution?.name || null,
       labels: fields?.labels || [],
       created: fields?.created || '',
@@ -137,8 +138,8 @@ export class JiraClient {
       resolutionDate: fields?.resolutiondate || null,
       dueDate: fields?.duedate || null,
       startDate: fields?.[this.customFields.startDate] || null,
-      storyPoints: fields?.[this.customFields.storyPoints] || null,
-      timeEstimate: fields?.timeestimate || null,
+      storyPoints: fields?.[this.customFields.storyPoints] ?? null,
+      timeEstimate: fields?.timeestimate ?? null,
       issueLinks: (fields?.issuelinks || []).map((link: any) => ({
         type: link.type?.name || '',
         outward: link.outwardIssue?.key || null,
@@ -482,6 +483,55 @@ export class JiraClient {
       issueIdOrKey: issueKey,
       comment: TextProcessor.markdownToAdf(commentBody)
     });
+  }
+
+  /** Lightweight search returning only fields needed for analysis (no description, links, rendered HTML) */
+  async searchIssuesLean(jql: string, maxResults = 50, nextPageToken?: string): Promise<SearchResponse> {
+    try {
+      const cleanJql = jql.replace(/\\"/g, '"');
+      console.error(`Executing lean JQL search with query: ${cleanJql}${nextPageToken ? ' (page token)' : ''}`);
+
+      const leanFields = [
+        'summary', 'issuetype', 'priority', 'assignee', 'reporter',
+        'status', 'resolution', 'labels', 'created', 'updated',
+        'resolutiondate', 'duedate', 'timeestimate',
+        this.customFields.startDate, this.customFields.storyPoints,
+      ];
+
+      const params: any = {
+        jql: cleanJql,
+        maxResults: Math.min(maxResults, 50),
+        fields: leanFields,
+      };
+      if (nextPageToken) {
+        params.nextPageToken = nextPageToken;
+      }
+
+      const timeoutMs = 30_000;
+      const searchResults = await Promise.race([
+        this.client.issueSearch.searchForIssuesUsingJqlEnhancedSearch(params),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`Lean search timed out after ${timeoutMs / 1000}s — try a narrower JQL query or smaller maxResults`)), timeoutMs)
+        ),
+      ]);
+
+      const issues = (searchResults.issues || []).map(issue => this.mapIssueFields(issue));
+      const hasMore = !!searchResults.nextPageToken;
+
+      return {
+        issues,
+        pagination: {
+          startAt: 0,
+          maxResults,
+          total: hasMore ? issues.length + 1 : issues.length,
+          hasMore,
+          nextPageToken: searchResults.nextPageToken || undefined,
+        }
+      };
+    } catch (error) {
+      console.error('Error executing lean JQL search:', error);
+      throw error;
+    }
   }
 
   async searchIssues(jql: string, startAt = 0, maxResults = 25): Promise<SearchResponse> {

--- a/src/docs/tool-documentation.ts
+++ b/src/docs/tool-documentation.ts
@@ -17,6 +17,7 @@ const documentationGenerators: Record<string, (schema: any) => any> = {
   manage_jira_filter: generateFilterToolDocumentation,
   manage_jira_project: generateProjectToolDocumentation,
   queue_jira_operations: generateQueueToolDocumentation,
+  analyze_jira_issues: generateAnalysisToolDocumentation,
 };
 
 export function generateToolDocumentation(toolName: string, schema: any): any {
@@ -466,6 +467,60 @@ function generateQueueToolDocumentation(_schema: any) {
       description: "Destructive operations (delete, move) are pre-scanned against the bulk-destructive limit. If the queue would exceed the limit, the entire queue is refused before any operations execute.",
       max_operations: 10,
     },
+    related_resources: [],
+  };
+}
+
+function generateAnalysisToolDocumentation(schema: any) {
+  return {
+    name: "Issue Analysis",
+    description: schema.description,
+    parameters: {
+      jql: {
+        type: "string",
+        description: "JQL query selecting the issues to analyze.",
+        required: true,
+      },
+      metrics: {
+        type: "array of strings",
+        description: "Which metric groups to include. Default: all.",
+        values: ["points", "time", "schedule", "cycle", "distribution"],
+      },
+      maxResults: {
+        type: "integer",
+        description: "Max issues to analyze (default 100, max 500).",
+      },
+    },
+    metric_groups: {
+      points: "Earned Value — PV, EV, remaining, SPI, status breakdown, unestimated count",
+      time: "Effort — original estimate, completed, remaining by status category",
+      schedule: "Risk — date window, overdue count/slip, due soon, concentration risk, missing dates",
+      cycle: "Flow — lead time median/mean, throughput, open issue age, oldest open",
+      distribution: "Composition — counts by status, assignee, priority, issue type",
+    },
+    common_use_cases: [
+      {
+        title: "Sprint health check",
+        description: "Analyze all issues in the current sprint:",
+        steps: [
+          { description: "Full analysis", code: { jql: "sprint in openSprints()" } },
+        ],
+      },
+      {
+        title: "Schedule risk for a release",
+        description: "Check overdue and upcoming deadlines:",
+        steps: [
+          { description: "Schedule only", code: { jql: "project = AA AND fixVersion = 2.0", metrics: ["schedule"] } },
+        ],
+      },
+      {
+        title: "Workload balance",
+        description: "See how work is distributed across team members:",
+        steps: [
+          { description: "Distribution only", code: { jql: "project = AA AND resolution = Unresolved", metrics: ["distribution"] } },
+        ],
+      },
+    ],
     related_resources: [],
   };
 }

--- a/src/handlers/analysis-handler.test.ts
+++ b/src/handlers/analysis-handler.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { renderPoints, renderTime, renderSchedule, renderCycle, renderDistribution } from './analysis-handler.js';
+import { JiraIssueDetails } from '../types/index.js';
+
+// ── Test Helpers ───────────────────────────────────────────────────────
+
+function makeIssue(overrides: Partial<JiraIssueDetails> = {}): JiraIssueDetails {
+  return {
+    key: 'TEST-1',
+    summary: 'Test issue',
+    description: '',
+    issueType: 'Story',
+    priority: 'Medium',
+    parent: null,
+    assignee: 'Alice',
+    reporter: 'Bob',
+    status: 'To Do',
+    statusCategory: 'new',
+    resolution: null,
+    labels: [],
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-02T00:00:00.000Z',
+    resolutionDate: null,
+    dueDate: null,
+    startDate: null,
+    storyPoints: null,
+    timeEstimate: null,
+    issueLinks: [],
+    ...overrides,
+  };
+}
+
+// ── Points ─────────────────────────────────────────────────────────────
+
+describe('renderPoints', () => {
+  it('computes SPI from story points by status category', () => {
+    const issues = [
+      makeIssue({ key: 'A-1', storyPoints: 5, statusCategory: 'done' }),
+      makeIssue({ key: 'A-2', storyPoints: 3, statusCategory: 'indeterminate' }),
+      makeIssue({ key: 'A-3', storyPoints: 2, statusCategory: 'new' }),
+    ];
+    const output = renderPoints(issues);
+    expect(output).toContain('| Planned Value (PV) | 10 pts |');
+    expect(output).toContain('| Earned Value (EV) | 5 pts |');
+    expect(output).toContain('| Remaining | 5 pts |');
+    expect(output).toContain('| SPI | 0.50 |');
+  });
+
+  it('shows N/A when no issues have story points', () => {
+    const issues = [makeIssue(), makeIssue({ key: 'A-2' })];
+    const output = renderPoints(issues);
+    expect(output).toContain('N/A (no estimates)');
+    expect(output).toContain('| Unestimated | 2 issues |');
+  });
+
+  it('shows SPI 1.00 when all points are done', () => {
+    const issues = [
+      makeIssue({ storyPoints: 8, statusCategory: 'done' }),
+    ];
+    const output = renderPoints(issues);
+    expect(output).toContain('| SPI | 1.00 |');
+  });
+
+  it('breaks down points by status bucket', () => {
+    const issues = [
+      makeIssue({ storyPoints: 3, statusCategory: 'new' }),
+      makeIssue({ storyPoints: 5, statusCategory: 'indeterminate' }),
+      makeIssue({ storyPoints: 2, statusCategory: 'done' }),
+    ];
+    const output = renderPoints(issues);
+    expect(output).toContain('To Do: 3 pts');
+    expect(output).toContain('In Progress: 5 pts');
+    expect(output).toContain('Done: 2 pts');
+  });
+});
+
+// ── Time ───────────────────────────────────────────────────────────────
+
+describe('renderTime', () => {
+  it('sums time estimates by status bucket', () => {
+    const issues = [
+      makeIssue({ timeEstimate: 3600, statusCategory: 'done' }),      // 1h
+      makeIssue({ timeEstimate: 7200, statusCategory: 'new' }),       // 2h
+      makeIssue({ timeEstimate: 1800, statusCategory: 'indeterminate' }), // 30m
+    ];
+    const output = renderTime(issues);
+    expect(output).toContain('| Original Estimate | 3h 30m |');
+    expect(output).toContain('| Completed | 1h |');
+    expect(output).toContain('| Remaining | 2h 30m |');
+  });
+
+  it('counts unestimated issues', () => {
+    const issues = [
+      makeIssue({ timeEstimate: 3600 }),
+      makeIssue(),
+      makeIssue(),
+    ];
+    const output = renderTime(issues);
+    expect(output).toContain('| Unestimated | 2 issues |');
+  });
+
+  it('formats large durations as days', () => {
+    const issues = [
+      makeIssue({ timeEstimate: 8 * 3600 * 3, statusCategory: 'new' }), // 3 work days
+    ];
+    const output = renderTime(issues);
+    expect(output).toContain('3d');
+  });
+});
+
+// ── Schedule ───────────────────────────────────────────────────────────
+
+describe('renderSchedule', () => {
+  const now = new Date(2026, 2, 6); // Mar 6, 2026
+
+  it('detects overdue issues', () => {
+    const issues = [
+      makeIssue({ key: 'OD-1', dueDate: '2026-03-01' }),
+      makeIssue({ key: 'OD-2', dueDate: '2026-03-04' }),
+      makeIssue({ key: 'OK-1', dueDate: '2026-03-10' }),
+    ];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('**Overdue:** 2 issues');
+    expect(output).toContain('OD-1');
+    expect(output).toContain('OD-2');
+  });
+
+  it('does not count resolved issues as overdue', () => {
+    const issues = [
+      makeIssue({ dueDate: '2026-03-01', resolutionDate: '2026-03-02' }),
+    ];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('**Overdue:** none');
+  });
+
+  it('shows date window from earliest start to latest due', () => {
+    const issues = [
+      makeIssue({ startDate: '2026-02-01', dueDate: '2026-03-15' }),
+      makeIssue({ startDate: '2026-02-10', dueDate: '2026-03-01' }),
+    ];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('Feb 1, 2026');
+    expect(output).toContain('Mar 15, 2026');
+  });
+
+  it('detects concentration risk', () => {
+    const issues = [
+      makeIssue({ key: 'C-1', dueDate: '2026-03-10' }),
+      makeIssue({ key: 'C-2', dueDate: '2026-03-10' }),
+      makeIssue({ key: 'C-3', dueDate: '2026-03-10' }),
+    ];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('**Concentration:');
+    expect(output).toContain('3 issues');
+  });
+
+  it('counts issues with no due date', () => {
+    const issues = [
+      makeIssue({ dueDate: null }),
+      makeIssue({ dueDate: null }),
+      makeIssue({ dueDate: '2026-03-10' }),
+    ];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('**No due date:** 2 issues');
+  });
+
+  it('handles all dates missing gracefully', () => {
+    const issues = [makeIssue(), makeIssue()];
+    const output = renderSchedule(issues, now);
+    expect(output).not.toContain('**Window:**');
+    expect(output).toContain('**Overdue:** none');
+  });
+});
+
+// ── Cycle ──────────────────────────────────────────────────────────────
+
+describe('renderCycle', () => {
+  const now = new Date(2026, 2, 6); // Mar 6, 2026
+
+  it('computes lead time median and mean', () => {
+    const issues = [
+      makeIssue({ created: '2026-02-01T00:00:00.000Z', resolutionDate: '2026-02-04T00:00:00.000Z' }), // 3 days
+      makeIssue({ created: '2026-02-01T00:00:00.000Z', resolutionDate: '2026-02-08T00:00:00.000Z' }), // 7 days
+      makeIssue({ created: '2026-02-01T00:00:00.000Z', resolutionDate: '2026-02-11T00:00:00.000Z' }), // 10 days
+    ];
+    const output = renderCycle(issues, now);
+    expect(output).toContain('median 7.0 days');
+    // mean = (3+7+10)/3 = 6.67
+    expect(output).toContain('mean 6.7 days');
+    expect(output).toContain('3 issues');
+  });
+
+  it('computes throughput', () => {
+    const issues = [
+      makeIssue({ created: '2026-02-01T00:00:00.000Z', resolutionDate: '2026-02-08T00:00:00.000Z' }),
+      makeIssue({ created: '2026-02-01T00:00:00.000Z', resolutionDate: '2026-02-15T00:00:00.000Z' }),
+    ];
+    const output = renderCycle(issues, now);
+    expect(output).toContain('issues/week');
+  });
+
+  it('shows oldest open issues', () => {
+    const issues = [
+      makeIssue({ key: 'OLD-1', created: '2026-01-01T00:00:00.000Z' }),
+      makeIssue({ key: 'OLD-2', created: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const output = renderCycle(issues, now);
+    expect(output).toContain('OLD-1');
+    expect(output).toContain('OLD-2');
+    // OLD-1 should be listed first (older)
+    expect(output.indexOf('OLD-1')).toBeLessThan(output.indexOf('OLD-2'));
+  });
+
+  it('handles no resolved issues', () => {
+    const issues = [makeIssue()];
+    const output = renderCycle(issues, now);
+    expect(output).toContain('no resolved issues');
+  });
+});
+
+// ── Distribution ───────────────────────────────────────────────────────
+
+describe('renderDistribution', () => {
+  it('groups by status, assignee, priority, type', () => {
+    const issues = [
+      makeIssue({ status: 'To Do', assignee: 'Alice', priority: 'High', issueType: 'Story' }),
+      makeIssue({ status: 'To Do', assignee: 'Alice', priority: 'Medium', issueType: 'Story' }),
+      makeIssue({ status: 'Done', assignee: 'Bob', priority: 'High', issueType: 'Bug' }),
+    ];
+    const output = renderDistribution(issues);
+    expect(output).toContain('To Do: 2');
+    expect(output).toContain('Done: 1');
+    expect(output).toContain('Alice: 2');
+    expect(output).toContain('Bob: 1');
+    expect(output).toContain('High: 2');
+    expect(output).toContain('Medium: 1');
+    expect(output).toContain('Story: 2');
+    expect(output).toContain('Bug: 1');
+  });
+
+  it('shows Unassigned for null assignees', () => {
+    const issues = [makeIssue({ assignee: null })];
+    const output = renderDistribution(issues);
+    expect(output).toContain('Unassigned: 1');
+  });
+});
+
+// ── Edge Cases ─────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('renders points for a single issue', () => {
+    const issues = [makeIssue({ storyPoints: 5, statusCategory: 'new' })];
+    const output = renderPoints(issues);
+    expect(output).toContain('| Planned Value (PV) | 5 pts |');
+    expect(output).toContain('| SPI | 0.00 |');
+  });
+
+  it('renders schedule with a single overdue issue', () => {
+    const now = new Date(2026, 2, 6);
+    const issues = [makeIssue({ key: 'LATE-1', dueDate: '2026-03-01' })];
+    const output = renderSchedule(issues, now);
+    expect(output).toContain('**Overdue:** 1 issue,');
+    expect(output).toContain('LATE-1');
+  });
+});

--- a/src/handlers/analysis-handler.ts
+++ b/src/handlers/analysis-handler.ts
@@ -1,0 +1,370 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+import { JiraClient } from '../client/jira-client.js';
+import { JiraIssueDetails } from '../types/index.js';
+import { analysisNextSteps } from '../utils/next-steps.js';
+import { normalizeArgs } from '../utils/normalize-args.js';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+type MetricGroup = 'points' | 'time' | 'schedule' | 'cycle' | 'distribution';
+
+const ALL_METRICS: MetricGroup[] = ['points', 'time', 'schedule', 'cycle', 'distribution'];
+const MAX_ISSUES = 500;
+
+type StatusBucket = 'To Do' | 'In Progress' | 'Done';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function bucketStatus(category: string): StatusBucket {
+  switch (category) {
+    case 'new': return 'To Do';
+    case 'indeterminate': return 'In Progress';
+    case 'done': return 'Done';
+    default: return 'To Do';
+  }
+}
+
+/** Parse a date string to a Date without timezone shift for date-only values */
+function parseDate(dateStr: string): Date {
+  const dateOnly = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnly) {
+    const [, y, m, d] = dateOnly;
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  return new Date(dateStr);
+}
+
+function formatDateShort(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.round((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const days = Math.floor(hours / 8); // 8-hour work day
+  if (days > 0) {
+    const remainingHours = hours % 8;
+    return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+  }
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  return `${minutes}m`;
+}
+
+function countBy<T>(items: T[], keyFn: (item: T) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const key = keyFn(item);
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+function sumBy<T>(items: T[], valueFn: (item: T) => number | null): number {
+  return items.reduce((sum, item) => sum + (valueFn(item) || 0), 0);
+}
+
+function mapToString(map: Map<string, number>, separator = ' | '): string {
+  return [...map.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${k}: ${v}`)
+    .join(separator);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+// ── Metric Renderers (exported for testing) ────────────────────────────
+
+export function renderPoints(issues: JiraIssueDetails[]): string {
+  const estimated = issues.filter(i => i.storyPoints != null);
+  const unestimated = issues.length - estimated.length;
+
+  const byBucket = new Map<StatusBucket, number>();
+  for (const issue of issues) {
+    const bucket = bucketStatus(issue.statusCategory);
+    byBucket.set(bucket, (byBucket.get(bucket) ?? 0) + (issue.storyPoints ?? 0));
+  }
+
+  const pv = sumBy(issues, i => i.storyPoints);
+  const ev = byBucket.get('Done') ?? 0;
+  const remaining = pv - ev;
+  const spi = pv > 0 ? (ev / pv) : null;
+
+  const lines = ['## Points (Earned Value)', ''];
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Planned Value (PV) | ${pv} pts |`);
+  lines.push(`| Earned Value (EV) | ${ev} pts |`);
+  lines.push(`| Remaining | ${remaining} pts |`);
+  lines.push(`| SPI | ${spi !== null ? spi.toFixed(2) : 'N/A (no estimates)'} |`);
+  if (unestimated > 0) {
+    lines.push(`| Unestimated | ${unestimated} issue${unestimated !== 1 ? 's' : ''} |`);
+  }
+  lines.push('');
+
+  const bucketStr = ['To Do', 'In Progress', 'Done']
+    .map(b => `${b}: ${byBucket.get(b as StatusBucket) ?? 0} pts`)
+    .join(' | ');
+  lines.push(`**By status:** ${bucketStr}`);
+
+  return lines.join('\n');
+}
+
+export function renderTime(issues: JiraIssueDetails[]): string {
+  const estimated = issues.filter(i => i.timeEstimate != null);
+  const unestimated = issues.length - estimated.length;
+  const total = sumBy(issues, i => i.timeEstimate);
+
+  const byBucket = new Map<StatusBucket, number>();
+  for (const issue of issues) {
+    const bucket = bucketStatus(issue.statusCategory);
+    byBucket.set(bucket, (byBucket.get(bucket) ?? 0) + (issue.timeEstimate ?? 0));
+  }
+
+  const done = byBucket.get('Done') ?? 0;
+  const remaining = total - done;
+
+  const lines = ['## Time (Effort)', ''];
+  lines.push('| Metric | Value |');
+  lines.push('|--------|-------|');
+  lines.push(`| Original Estimate | ${formatDuration(total)} |`);
+  lines.push(`| Completed | ${formatDuration(done)} |`);
+  lines.push(`| Remaining | ${formatDuration(remaining)} |`);
+  if (unestimated > 0) {
+    lines.push(`| Unestimated | ${unestimated} issue${unestimated !== 1 ? 's' : ''} |`);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderSchedule(issues: JiraIssueDetails[], now: Date): string {
+  const lines = ['## Schedule', ''];
+
+  // Date range
+  const startDates = issues.filter(i => i.startDate).map(i => parseDate(i.startDate!));
+  const dueDates = issues.filter(i => i.dueDate).map(i => parseDate(i.dueDate!));
+  const allDates = [...startDates, ...dueDates];
+
+  if (allDates.length > 0) {
+    const earliest = new Date(Math.min(...allDates.map(d => d.getTime())));
+    const latest = new Date(Math.max(...allDates.map(d => d.getTime())));
+    lines.push(`**Window:** ${formatDateShort(earliest)} - ${formatDateShort(latest)}`);
+  }
+
+  // Overdue
+  const overdue = issues.filter(i =>
+    i.dueDate && !i.resolutionDate && parseDate(i.dueDate) < now
+  );
+  if (overdue.length > 0) {
+    const totalSlip = overdue.reduce((sum, i) => sum + daysBetween(parseDate(i.dueDate!), now), 0);
+    const keys = overdue.slice(0, 5).map(i => i.key).join(', ');
+    const more = overdue.length > 5 ? ` +${overdue.length - 5} more` : '';
+    lines.push(`**Overdue:** ${overdue.length} issue${overdue.length !== 1 ? 's' : ''}, ${totalSlip} days total slip (${keys}${more})`);
+  } else {
+    lines.push('**Overdue:** none');
+  }
+
+  // Due soon
+  for (const window of [7, 14, 30]) {
+    const cutoff = new Date(now.getTime() + window * 24 * 60 * 60 * 1000);
+    const dueSoon = issues.filter(i =>
+      i.dueDate && !i.resolutionDate &&
+      parseDate(i.dueDate) >= now && parseDate(i.dueDate) <= cutoff
+    );
+    if (dueSoon.length > 0) {
+      lines.push(`**Due next ${window} days:** ${dueSoon.length} issue${dueSoon.length !== 1 ? 's' : ''}`);
+    }
+  }
+
+  // Concentration risk
+  const dueDateCounts = countBy(
+    issues.filter(i => i.dueDate && !i.resolutionDate),
+    i => i.dueDate!
+  );
+  const concentrated = [...dueDateCounts.entries()]
+    .filter(([, count]) => count >= 3)
+    .sort((a, b) => b[1] - a[1]);
+  if (concentrated.length > 0) {
+    const top = concentrated.slice(0, 3)
+      .map(([date, count]) => `${formatDateShort(parseDate(date))} has ${count} issues`)
+      .join('; ');
+    lines.push(`**Concentration:** ${top}`);
+  }
+
+  // No due date
+  const noDueDate = issues.filter(i => !i.dueDate && !i.resolutionDate);
+  if (noDueDate.length > 0) {
+    lines.push(`**No due date:** ${noDueDate.length} issue${noDueDate.length !== 1 ? 's' : ''}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderCycle(issues: JiraIssueDetails[], now: Date): string {
+  const lines = ['## Cycle (Flow Metrics)', ''];
+
+  // Lead time for resolved issues
+  const resolved = issues.filter(i => i.resolutionDate && i.created);
+  if (resolved.length > 0) {
+    const leadTimes = resolved.map(i =>
+      daysBetween(parseDate(i.created), parseDate(i.resolutionDate!))
+    );
+    const med = median(leadTimes);
+    const avg = mean(leadTimes);
+    lines.push(`**Lead time (resolved):** median ${med.toFixed(1)} days, mean ${avg.toFixed(1)} days (${resolved.length} issues)`);
+
+    // Throughput
+    const createdDates = resolved.map(i => parseDate(i.resolutionDate!).getTime());
+    const earliest = Math.min(...createdDates);
+    const latest = Math.max(...createdDates);
+    const weeks = Math.max(1, (latest - earliest) / (7 * 24 * 60 * 60 * 1000));
+    const throughput = resolved.length / weeks;
+    lines.push(`**Throughput:** ${throughput.toFixed(1)} issues/week`);
+  } else {
+    lines.push('**Lead time:** no resolved issues in set');
+  }
+
+  // Age of open issues
+  const open = issues.filter(i => !i.resolutionDate && i.created);
+  if (open.length > 0) {
+    const ages = open.map(i => daysBetween(parseDate(i.created), now));
+    const avgAge = mean(ages);
+    lines.push(`**Open issue age:** mean ${avgAge.toFixed(1)} days (${open.length} issues)`);
+
+    // Oldest open
+    const oldest = open
+      .map(i => ({ key: i.key, age: daysBetween(parseDate(i.created), now) }))
+      .sort((a, b) => b.age - a.age)
+      .slice(0, 5);
+    const oldestStr = oldest.map(o => `${o.key} (${o.age}d)`).join(', ');
+    lines.push(`**Oldest open:** ${oldestStr}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function renderDistribution(issues: JiraIssueDetails[]): string {
+  const lines = ['## Distribution', ''];
+
+  const byStatus = countBy(issues, i => i.status);
+  lines.push(`**By status:** ${mapToString(byStatus)}`);
+
+  const byAssignee = countBy(issues, i => i.assignee || 'Unassigned');
+  lines.push(`**By assignee:** ${mapToString(byAssignee)}`);
+
+  const byPriority = countBy(issues, i => i.priority || 'None');
+  lines.push(`**By priority:** ${mapToString(byPriority)}`);
+
+  const byType = countBy(issues, i => i.issueType || 'Unknown');
+  lines.push(`**By type:** ${mapToString(byType)}`);
+
+  return lines.join('\n');
+}
+
+// ── Main Handler ───────────────────────────────────────────────────────
+
+export async function handleAnalysisRequest(jiraClient: JiraClient, request: any) {
+  const args = normalizeArgs(request.params?.arguments || {});
+
+  const jql = args.jql as string;
+  if (!jql || typeof jql !== 'string' || jql.trim() === '') {
+    throw new McpError(ErrorCode.InvalidParams, 'jql parameter is required.');
+  }
+
+  const DEFAULT_MAX = 100;
+  const maxResults = Math.min(Number(args.maxResults) || DEFAULT_MAX, MAX_ISSUES);
+
+  // Parse requested metrics
+  let metrics: MetricGroup[] = ALL_METRICS;
+  if (args.metrics && Array.isArray(args.metrics)) {
+    const requested = args.metrics as string[];
+    const valid = requested.filter(m => ALL_METRICS.includes(m as MetricGroup));
+    if (valid.length > 0) metrics = valid as MetricGroup[];
+  }
+
+  // Fetch issues using cursor-based pagination (50 per page, Jira enhanced search API)
+  const allIssues: JiraIssueDetails[] = [];
+  const seen = new Set<string>();
+  let nextPageToken: string | undefined;
+  let truncated = false;
+  const maxPages = Math.ceil(maxResults / 50) + 1;
+  let pageCount = 0;
+
+  while (allIssues.length < maxResults) {
+    if (++pageCount > maxPages) break;
+    const remaining = maxResults - allIssues.length;
+    const result = await jiraClient.searchIssuesLean(jql, Math.min(50, remaining), nextPageToken);
+    for (const issue of result.issues) {
+      if (!seen.has(issue.key)) {
+        seen.add(issue.key);
+        allIssues.push(issue);
+      }
+    }
+
+    if (!result.pagination.hasMore || result.issues.length === 0) break;
+    nextPageToken = result.pagination.nextPageToken;
+
+    if (allIssues.length >= maxResults) {
+      truncated = result.pagination.hasMore;
+      break;
+    }
+  }
+
+  if (allIssues.length === 0) {
+    return {
+      content: [{
+        type: 'text',
+        text: `# Analysis\n\n**JQL:** \`${jql}\`\n\nNo issues matched this query.`,
+      }],
+    };
+  }
+
+  const now = new Date();
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# Analysis: ${jql}`);
+  lines.push(`Analyzed ${allIssues.length} issues (as of ${formatDateShort(now)})`);
+  if (truncated) {
+    lines.push(`*Results capped at ${maxResults} issues — query may match more.*`);
+  }
+
+  // Render requested metrics
+  const renderers: Record<MetricGroup, () => string> = {
+    points: () => renderPoints(allIssues),
+    time: () => renderTime(allIssues),
+    schedule: () => renderSchedule(allIssues, now),
+    cycle: () => renderCycle(allIssues, now),
+    distribution: () => renderDistribution(allIssues),
+  };
+
+  for (const metric of metrics) {
+    lines.push('');
+    lines.push(renderers[metric]());
+  }
+
+  // Next steps
+  const nextSteps = analysisNextSteps(jql, allIssues.slice(0, 3).map(i => i.key));
+  lines.push(nextSteps);
+
+  return {
+    content: [{
+      type: 'text',
+      text: lines.join('\n'),
+    }],
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 
 import { fieldDiscovery } from './client/field-discovery.js';
 import { JiraClient } from './client/jira-client.js';
+import { handleAnalysisRequest } from './handlers/analysis-handler.js';
 import { handleBoardRequest } from './handlers/board-handlers.js';
 import { handleFilterRequest } from './handlers/filter-handlers.js';
 import { handleIssueRequest } from './handlers/issue-handlers.js';
@@ -119,6 +120,7 @@ class JiraServer {
           manage_jira_board: handleBoardRequest,
           manage_jira_sprint: handleSprintRequest,
           manage_jira_filter: handleFilterRequest,
+          analyze_jira_issues: handleAnalysisRequest,
         };
 
         const handlers: Record<string, (client: JiraClient, req: typeof request) => Promise<any>> = {

--- a/src/schemas/tool-schemas.test.ts
+++ b/src/schemas/tool-schemas.test.ts
@@ -9,10 +9,10 @@ const DOMAIN_TOOLS = [
   'manage_jira_sprint',
 ];
 
-const ALL_TOOLS = [...DOMAIN_TOOLS, 'queue_jira_operations'];
+const ALL_TOOLS = [...DOMAIN_TOOLS, 'analyze_jira_issues', 'queue_jira_operations'];
 
 describe('toolSchemas', () => {
-  it('exports all 6 tools', () => {
+  it('exports all 7 tools', () => {
     expect(Object.keys(toolSchemas).sort()).toEqual(ALL_TOOLS.sort());
   });
 

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -330,6 +330,34 @@ export const toolSchemas = {
   },
 
 
+  analyze_jira_issues: {
+    name: 'analyze_jira_issues',
+    description: 'Compute project metrics over a set of issues selected by JQL. Returns deterministic calculations: earned value (story points), effort tracking, schedule risk, flow/cycle metrics, and distribution breakdowns. Use this when asked about totals, progress, overdue items, workload balance, or any quantitative question about issues.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        jql: {
+          type: 'string',
+          description: 'JQL query selecting the issues to analyze. Examples: "sprint in openSprints()", "project = AA AND fixVersion = 2.0", "assignee = currentUser() AND resolution = Unresolved".',
+        },
+        metrics: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['points', 'time', 'schedule', 'cycle', 'distribution'],
+          },
+          description: 'Which metric groups to include. Default: all. points = earned value/SPI, time = effort estimates, schedule = due dates/overdue/risk, cycle = lead time/throughput/age, distribution = counts by status/assignee/priority/type.',
+        },
+        maxResults: {
+          type: 'integer',
+          description: 'Max issues to analyze (default 100, max 500).',
+          default: 100,
+        },
+      },
+      required: ['jql'],
+    },
+  },
+
   queue_jira_operations: {
     name: 'queue_jira_operations',
     description: 'Execute multiple Jira operations in a single call. Operations run sequentially with result references ($0.key) and per-operation error strategies (bail/continue).',
@@ -343,7 +371,7 @@ export const toolSchemas = {
             properties: {
               tool: {
                 type: 'string',
-                enum: ['manage_jira_issue', 'manage_jira_filter', 'manage_jira_sprint', 'manage_jira_project', 'manage_jira_board'],
+                enum: ['manage_jira_issue', 'manage_jira_filter', 'manage_jira_sprint', 'manage_jira_project', 'manage_jira_board', 'analyze_jira_issues'],
                 description: 'Which tool to call.',
               },
               args: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface JiraIssueDetails {
   assignee: string | null;
   reporter: string;
   status: string;
+  statusCategory: 'new' | 'indeterminate' | 'done' | 'unknown';
   resolution: string | null;
   labels: string[];
   created: string;
@@ -100,6 +101,7 @@ export interface SearchPagination {
   maxResults: number;
   total: number;
   hasMore: boolean;
+  nextPageToken?: string;
 }
 
 export interface SearchResponse {

--- a/src/utils/next-steps.ts
+++ b/src/utils/next-steps.ts
@@ -201,3 +201,17 @@ export function boardNextSteps(operation: string, boardId?: number): string {
   }
   return steps.length > 0 ? formatSteps(steps) : '';
 }
+
+export function analysisNextSteps(jql: string, issueKeys: string[]): string {
+  const steps: NextStep[] = [];
+  if (issueKeys.length > 0) {
+    steps.push(
+      { description: 'Get details on a specific issue', tool: 'manage_jira_issue', example: { operation: 'get', issueKey: issueKeys[0] } },
+    );
+  }
+  steps.push(
+    { description: 'Narrow the analysis with refined JQL', tool: 'analyze_jira_issues', example: { jql: `${jql} AND priority = High` } },
+    { description: 'View the full issue list', tool: 'manage_jira_filter', example: { operation: 'execute_jql', jql } },
+  );
+  return formatSteps(steps);
+}


### PR DESCRIPTION
## Summary

New `analyze_jira_issues` tool for deterministic PM calculations over JQL-selected issue sets.

- **5 metric groups**: earned value (SPI), effort tracking, schedule risk, flow/cycle metrics, distribution breakdowns
- **Lean search**: `searchIssuesLean()` fetches only metric-relevant fields — no description, no rendered fields
- **Cursor-based pagination**: proper Jira enhanced search API windowing (50/page), supports up to 500 issues
- **Zero-value fix**: `|| null` → `?? null` for storyPoints/timeEstimate so `0` isn't treated as null

Grounded in EVM and Lean/Kanban methodologies. See ADR-204.

## Test plan

- [x] 21 unit tests covering all 5 renderers + edge cases (198 total pass)
- [x] Live tested against IM (4 issues), AA (100 issues), REQ (500 issues)
- [x] Verified REQ 500-issue query completes instantly with lean search + cursor pagination
- [x] Code review via agent — addressed all findings