### PR TITLE
feat: soft group limits and semantic steering for counting queries

### DIFF
--- a/src/handlers/analysis-handler.test.ts
+++ b/src/handlers/analysis-handler.test.ts
@@ -244,6 +244,27 @@ describe('renderDistribution', () => {
     const output = renderDistribution(issues);
     expect(output).toContain('Unassigned: 1');
   });
+
+  it('caps distribution values at groupLimit with hint', () => {
+    const issues = Array.from({ length: 10 }, (_, i) =>
+      makeIssue({ key: `T-${i}`, assignee: `User${i}` })
+    );
+    const output = renderDistribution(issues, 3);
+    expect(output).toContain('User0: 1');
+    expect(output).toContain('+7 more');
+    expect(output).toContain('groupLimit');
+  });
+
+  it('shows all values when groupLimit is large', () => {
+    const issues = [
+      makeIssue({ assignee: 'Alice' }),
+      makeIssue({ assignee: 'Bob' }),
+    ];
+    const output = renderDistribution(issues, 100);
+    expect(output).toContain('Alice: 1');
+    expect(output).toContain('Bob: 1');
+    expect(output).not.toContain('more');
+  });
 });
 
 // ── Edge Cases ─────────────────────────────────────────────────────────
@@ -453,7 +474,7 @@ describe('extractDimensions', () => {
     expect(assignee.values).toEqual(['Unassigned']);
   });
 
-  it('caps values at 20 groups', () => {
+  it('caps values at default 20 groups', () => {
     // Create 25 distinct statuses
     const issues = Array.from({ length: 25 }, (_, i) =>
       makeIssue({ key: `T-${i + 1}`, status: `Status${i}` })
@@ -462,6 +483,26 @@ describe('extractDimensions', () => {
     const status = dims.find(d => d.name === 'status')!;
     expect(status.values.length).toBe(20);
     expect(status.count).toBe(25);
+  });
+
+  it('respects custom groupLimit', () => {
+    const issues = Array.from({ length: 25 }, (_, i) =>
+      makeIssue({ key: `T-${i + 1}`, status: `Status${i}` })
+    );
+    const dims = extractDimensions(issues, 10);
+    const status = dims.find(d => d.name === 'status')!;
+    expect(status.values.length).toBe(10);
+    expect(status.count).toBe(25);
+  });
+
+  it('returns all values when groupLimit exceeds count', () => {
+    const issues = Array.from({ length: 5 }, (_, i) =>
+      makeIssue({ key: `T-${i + 1}`, status: `Status${i}` })
+    );
+    const dims = extractDimensions(issues, 100);
+    const status = dims.find(d => d.name === 'status')!;
+    expect(status.values.length).toBe(5);
+    expect(status.count).toBe(5);
   });
 });
 

--- a/src/handlers/analysis-handler.ts
+++ b/src/handlers/analysis-handler.ts
@@ -13,11 +13,12 @@ type MetricGroup = 'points' | 'time' | 'schedule' | 'cycle' | 'distribution' | '
 const ALL_METRICS: MetricGroup[] = ['points', 'time', 'schedule', 'cycle', 'distribution'];
 const VALID_GROUP_BY = ['project', 'assignee', 'priority', 'issuetype'] as const;
 type GroupByField = typeof VALID_GROUP_BY[number];
-const MAX_ISSUES = 500;
+const MAX_ISSUES_HARD = 500;   // absolute ceiling for detail metrics — beyond this, context explodes
+const MAX_ISSUES_DEFAULT = 100;
 const CUBE_SAMPLE_PCT = 0.2;   // 20% of total issues
 const CUBE_SAMPLE_MIN = 50;    // floor — enough for rare dimension values
 const CUBE_SAMPLE_MAX = 500;   // ceiling — proven fast with lean search
-const MAX_CUBE_GROUPS = 20;
+const DEFAULT_GROUP_LIMIT = 20;
 const MAX_COUNT_QUERIES = 150; // ADR-206 budget: max count API calls per execution
 const STANDARD_MEASURES = 6;   // total, open, overdue, high+, created_7d, resolved_7d
 
@@ -77,11 +78,14 @@ function sumBy<T>(items: T[], valueFn: (item: T) => number | null): number {
   return items.reduce((sum, item) => sum + (valueFn(item) || 0), 0);
 }
 
-function mapToString(map: Map<string, number>, separator = ' | '): string {
-  return [...map.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([k, v]) => `${k}: ${v}`)
-    .join(separator);
+function mapToString(map: Map<string, number>, separator = ' | ', limit?: number): string {
+  const sorted = [...map.entries()].sort((a, b) => b[1] - a[1]);
+  const capped = limit ? sorted.slice(0, limit) : sorted;
+  const result = capped.map(([k, v]) => `${k}: ${v}`).join(separator);
+  if (limit && sorted.length > limit) {
+    return `${result} | (+${sorted.length - limit} more — use groupLimit to see all)`;
+  }
+  return result;
 }
 
 function median(values: number[]): number {
@@ -310,20 +314,20 @@ export function renderCycle(issues: JiraIssueDetails[], now: Date): string {
   return lines.join('\n');
 }
 
-export function renderDistribution(issues: JiraIssueDetails[]): string {
+export function renderDistribution(issues: JiraIssueDetails[], groupLimit = DEFAULT_GROUP_LIMIT): string {
   const lines = ['## Distribution', ''];
 
   const byStatus = countBy(issues, i => i.status);
-  lines.push(`**By status:** ${mapToString(byStatus)}`);
+  lines.push(`**By status:** ${mapToString(byStatus, ' | ', groupLimit)}`);
 
   const byAssignee = countBy(issues, i => i.assignee || 'Unassigned');
-  lines.push(`**By assignee:** ${mapToString(byAssignee)}`);
+  lines.push(`**By assignee:** ${mapToString(byAssignee, ' | ', groupLimit)}`);
 
   const byPriority = countBy(issues, i => i.priority || 'None');
-  lines.push(`**By priority:** ${mapToString(byPriority)}`);
+  lines.push(`**By priority:** ${mapToString(byPriority, ' | ', groupLimit)}`);
 
   const byType = countBy(issues, i => i.issueType || 'Unknown');
-  lines.push(`**By type:** ${mapToString(byType)}`);
+  lines.push(`**By type:** ${mapToString(byType, ' | ', groupLimit)}`);
 
   return lines.join('\n');
 }
@@ -508,7 +512,7 @@ function maxGroupsForBudget(implicitCount: number): number {
   return Math.floor(MAX_COUNT_QUERIES / queriesPerGroup);
 }
 
-async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: GroupByField, compute?: ComputeColumn[]): Promise<string> {
+async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: GroupByField, compute?: ComputeColumn[], groupLimit = DEFAULT_GROUP_LIMIT): Promise<string> {
   const lines: string[] = [];
   lines.push(`# Summary: ${jql}`);
   lines.push(`As of ${formatDateShort(new Date())} — counts are exact (no sampling cap)`);
@@ -518,13 +522,16 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
   const neededImplicits = compute ? detectImplicitMeasures(compute, implicitDefs) : [];
   const groupBudget = maxGroupsForBudget(neededImplicits.length);
 
+  // Effective group cap: user's preference vs API query budget (whichever is smaller)
+  const effectiveGroupCap = Math.min(groupLimit, groupBudget);
+
   if (groupBy === 'project') {
     let keys = extractProjectKeys(jql);
     if (keys.length === 0) {
       throw new McpError(ErrorCode.InvalidParams, 'groupBy "project" requires project keys in JQL (e.g., project in (AA, GC))');
     }
-    const capped = keys.length > groupBudget;
-    if (capped) keys = keys.slice(0, groupBudget);
+    const capped = keys.length > effectiveGroupCap;
+    if (capped) keys = keys.slice(0, effectiveGroupCap);
     const remaining = removeProjectClause(jql);
     const rows = await batchParallel(
       keys.map(k => () => buildCountRow(jiraClient, k,
@@ -537,7 +544,10 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
     lines.push('');
     lines.push(renderSummaryTable(rows, compute));
     if (capped) {
-      lines.push(`*Capped at ${groupBudget} groups to stay within ${MAX_COUNT_QUERIES}-query budget*`);
+      const reason = effectiveGroupCap < groupBudget
+        ? `groupLimit=${effectiveGroupCap} — increase groupLimit to see more`
+        : `${MAX_COUNT_QUERIES}-query budget`;
+      lines.push(`*Capped at ${effectiveGroupCap} groups (${reason})*`);
     }
   } else if (groupBy) {
     // For non-project groupBy, sample per-project for representative dimension values
@@ -545,14 +555,14 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
     if (issues.length === 0) {
       throw new McpError(ErrorCode.InvalidParams, `No issues matched JQL — cannot discover ${groupBy} values`);
     }
-    const dims = extractDimensions(issues);
+    const dims = extractDimensions(issues, groupLimit);
     const dim = dims.find(d => d.name === groupBy);
     if (!dim || dim.values.length === 0) {
       throw new McpError(ErrorCode.InvalidParams, `No ${groupBy} values found in sampled issues`);
     }
 
-    // Cap groups to query budget
-    const cappedValues = dim.values.slice(0, groupBudget);
+    // Cap groups to effective limit
+    const cappedValues = dim.values.slice(0, effectiveGroupCap);
 
     const jqlClause = groupByJqlClause(groupBy, cappedValues);
     const rows = await batchParallel(
@@ -566,10 +576,15 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
     lines.push('');
     lines.push(renderSummaryTable(rows, compute));
     if (dim.count > cappedValues.length) {
-      const reason = cappedValues.length < dim.values.length
-        ? `capped at ${groupBudget} groups (${MAX_COUNT_QUERIES}-query budget)`
-        : `from ${issues.length}-issue sample`;
-      lines.push(`*Showing top ${cappedValues.length} of ${dim.count} ${groupBy} values (${reason})*`);
+      const reasons: string[] = [];
+      if (cappedValues.length < dim.values.length) {
+        reasons.push(effectiveGroupCap < groupBudget
+          ? `groupLimit=${effectiveGroupCap} — increase groupLimit to see more`
+          : `${MAX_COUNT_QUERIES}-query budget`);
+      } else {
+        reasons.push(`from ${issues.length}-issue sample`);
+      }
+      lines.push(`*Showing top ${cappedValues.length} of ${dim.count} ${groupBy} values (${reasons.join(', ')})*`);
     }
   } else {
     // No groupBy — single row for the whole JQL
@@ -596,7 +611,7 @@ interface DimensionInfo {
 }
 
 /** Extract distinct dimension values from sampled issues */
-export function extractDimensions(issues: JiraIssueDetails[]): DimensionInfo[] {
+export function extractDimensions(issues: JiraIssueDetails[], groupLimit = DEFAULT_GROUP_LIMIT): DimensionInfo[] {
   const dims: { name: string; extractor: (i: JiraIssueDetails) => string }[] = [
     { name: 'project', extractor: i => i.key.split('-')[0] },
     { name: 'status', extractor: i => i.status },
@@ -611,10 +626,10 @@ export function extractDimensions(issues: JiraIssueDetails[]): DimensionInfo[] {
       const val = extractor(issue);
       counts.set(val, (counts.get(val) || 0) + 1);
     }
-    // Sort by count descending, cap at MAX_CUBE_GROUPS
+    // Sort by count descending, cap at groupLimit
     const sorted = [...counts.entries()]
       .sort((a, b) => b[1] - a[1])
-      .slice(0, MAX_CUBE_GROUPS);
+      .slice(0, groupLimit);
     return {
       name,
       values: sorted.map(([v]) => v),
@@ -650,7 +665,7 @@ export function renderCubeSetup(jql: string, sampleSize: number, dimensions: Dim
   lines.push('');
   lines.push(`## Suggested Cubes (budget: ${MAX_COUNT_QUERIES} queries)`);
   for (const dim of dimensions) {
-    const groups = Math.min(dim.count, MAX_CUBE_GROUPS);
+    const groups = Math.min(dim.count, DEFAULT_GROUP_LIMIT);
     const queries = groups * STANDARD_MEASURES;
     const estSeconds = Math.max(1, Math.round(queries / 12)); // ~12 parallel queries/sec
     const withinBudget = queries <= MAX_COUNT_QUERIES;
@@ -744,6 +759,10 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
     compute = parseComputeList(args.compute as string[]);
   }
 
+  // Parse groupLimit — soft cap on group/dimension values (no hard cap for summary metrics)
+  const rawGroupLimit = Number(args.groupLimit);
+  const groupLimit = rawGroupLimit > 0 ? rawGroupLimit : DEFAULT_GROUP_LIMIT;
+
   // Cube setup — discover dimensions from sample, no issue fetching
   if (hasCubeSetup) {
     const cubeText = await handleCubeSetup(jiraClient, jql);
@@ -758,7 +777,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
 
   // If only summary requested, skip issue fetching entirely
   if (hasSummary && fetchMetrics.length === 0) {
-    const summaryText = await handleSummary(jiraClient, jql, groupBy, compute);
+    const summaryText = await handleSummary(jiraClient, jql, groupBy, compute, groupLimit);
     const nextSteps = analysisNextSteps(jql, []);
     return {
       content: [{
@@ -768,8 +787,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
     };
   }
 
-  const DEFAULT_MAX = 100;
-  const maxResults = Math.min(Number(args.maxResults) || DEFAULT_MAX, MAX_ISSUES);
+  const maxResults = Math.min(Number(args.maxResults) || MAX_ISSUES_DEFAULT, MAX_ISSUES_HARD);
 
   // Fetch issues using cursor-based pagination (50 per page, Jira enhanced search API)
   const allIssues: JiraIssueDetails[] = [];
@@ -813,7 +831,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
 
   // Summary first if requested alongside other metrics
   if (hasSummary) {
-    const summaryText = await handleSummary(jiraClient, jql, groupBy, compute);
+    const summaryText = await handleSummary(jiraClient, jql, groupBy, compute, groupLimit);
     lines.push(summaryText);
   }
 
@@ -823,7 +841,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
     lines.push(`# Detail: ${jql}`);
     lines.push(`Analyzed ${allIssues.length} issues (as of ${formatDateShort(now)})`);
     if (truncated) {
-      lines.push(`*Results capped at ${maxResults} issues — query may match more.*`);
+      lines.push(`*Results capped at ${maxResults} issues — distributions below are approximate. For exact counts, use metrics: ["summary"] with groupBy instead.*`);
     }
 
     // Render requested metrics
@@ -832,7 +850,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
       time: () => renderTime(allIssues),
       schedule: () => renderSchedule(allIssues, now),
       cycle: () => renderCycle(allIssues, now),
-      distribution: () => renderDistribution(allIssues),
+      distribution: () => renderDistribution(allIssues, groupLimit),
     };
 
     for (const metric of fetchMetrics) {

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -332,7 +332,7 @@ export const toolSchemas = {
 
   analyze_jira_issues: {
     name: 'analyze_jira_issues',
-    description: 'Compute project metrics over issues selected by JQL. Use "summary" for exact counts across projects (no sampling cap). Use other metrics for detailed analysis of individual issue data. Always prefer this tool over manage_jira_filter or manage_jira_project for quantitative questions (counts, totals, overdue, workload). Read jira://analysis/recipes for composition patterns.',
+    description: 'Compute project metrics over issues selected by JQL. For counting and breakdown questions ("how many by status/assignee/priority"), use metrics: ["summary"] with groupBy — this gives exact counts with no issue cap. Use detail metrics (points, time, schedule, cycle, distribution) only when you need per-issue analysis; these are capped at maxResults issues. Always prefer this tool over manage_jira_filter or manage_jira_project for quantitative questions. Read jira://analysis/recipes for composition patterns.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -346,18 +346,23 @@ export const toolSchemas = {
             type: 'string',
             enum: ['summary', 'points', 'time', 'schedule', 'cycle', 'distribution', 'cube_setup'],
           },
-          description: 'Which metric groups to compute. summary = exact issue counts via count API (no cap, fastest). cube_setup = sample issues and discover available dimensions/measures for cube queries. points = earned value/SPI. time = effort estimates. schedule = overdue/risk. cycle = lead time/throughput. distribution = counts by status/assignee/priority/type. Default: all except summary and cube_setup.',
+          description: 'Which metric groups to compute. summary = exact counts via count API (no issue cap, fastest) — use with groupBy for "how many by assignee/status/priority" questions. distribution = approximate counts from fetched issues (capped by maxResults — use summary + groupBy instead when you need exact counts). cube_setup = discover dimensions before cube queries. points = earned value/SPI. time = effort estimates. schedule = overdue/risk. cycle = lead time/throughput. Default: all detail metrics. For counting/breakdown questions, always prefer summary + groupBy over distribution.',
         },
         groupBy: {
           type: 'string',
           enum: ['project', 'assignee', 'priority', 'issuetype'],
-          description: 'Split summary counts by this dimension. Use with metrics: ["summary"]. "project" produces a per-project comparison table.',
+          description: 'Split counts by this dimension — produces a breakdown table. Use with metrics: ["summary"] for exact counts. This is the correct approach for "how many issues per assignee/priority/type" questions. "project" produces a per-project comparison.',
         },
         compute: {
           type: 'array',
           items: { type: 'string' },
           description: 'Computed columns for cube execute. Each entry: "name = expr". Arithmetic (+,-,*,/), comparisons (>,<,>=,<=,==,!=). Column refs: total, open, overdue, high, created_7d, resolved_7d. Implicit measures resolved lazily: bugs, unassigned, no_due_date, no_estimate, no_start_date, no_labels, blocked, stale (untouched 60d+), stale_status (stuck in status 30d+), backlog_rot (undated+unassigned+untouched 60d+). Max 5 expressions. Example: ["bug_pct = bugs / total * 100", "rot_pct = backlog_rot / open * 100"].',
           maxItems: 5,
+        },
+        groupLimit: {
+          type: 'integer',
+          description: 'Max groups/dimension values to show (default 20). Applies to summary groupBy rows and distribution breakdowns. No hard cap for summary metrics — increase freely for full visibility. For detail metrics the issue fetch is separately capped by maxResults.',
+          default: 20,
         },
         maxResults: {
           type: 'integer',

--- a/src/utils/next-steps.ts
+++ b/src/utils/next-steps.ts
@@ -217,7 +217,8 @@ export function analysisNextSteps(jql: string, issueKeys: string[], truncated = 
   );
   if (truncated) {
     steps.push(
-      { description: 'Detail metrics are sampled — narrow JQL by assignee, priority, or type for precise results. Use summary metrics (count API) for whole-project totals', tool: 'analyze_jira_issues', example: { jql: `${jql} AND assignee = currentUser()`, metrics: ['cycle'] } },
+      { description: 'Distribution counts above are approximate (issue cap hit). For exact breakdowns use summary + groupBy', tool: 'analyze_jira_issues', example: { jql, metrics: ['summary'], groupBy: 'assignee' } },
+      { description: 'Or narrow JQL for precise detail metrics', tool: 'analyze_jira_issues', example: { jql: `${jql} AND assignee = currentUser()`, metrics: ['cycle'] } },
     );
   }
   return formatSteps(steps) + '\n- Read `jira://analysis/recipes` for data cube patterns and compute DSL examples';


### PR DESCRIPTION
## Summary
- Adds `groupLimit` parameter to `analyze_jira_issues` (default 20, no hard cap for summary metrics) so LLMs can request more groups when needed
- Steers LLMs toward `summary` + `groupBy` for counting/breakdown questions instead of `distribution` which is capped at 500 fetched issues
- When distribution is truncated, output now redirects to the exact approach instead of a vague "may match more" note

## Problem
LLMs were using `distribution` (fetches issues, capped at 500) for "how many issues does X have" questions. On a 2,561-issue tree, this produced approximate counts with a "capped at 500" asterisk instead of exact counts via the count API.

## Test plan
- [x] `make check` passes (290 tests, lint clean, build OK)
- [x] Tested live against `portfolioChildIssuesOf("IP-89")` — 2,561 issues, 23 assignees, exact counts with no cap
- [ ] Verify Claude Desktop picks `summary` + `groupBy` for counting questions after rebuild