### PR TITLE
feat: workload decomposition steering for assignee queries

### DIFF
--- a/src/handlers/analysis-handler.ts
+++ b/src/handlers/analysis-handler.ts
@@ -593,6 +593,12 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
     lines.push(renderSummaryTable([row], compute));
   }
 
+  // Workload interpretation hint — steer LLMs to decompose before reporting raw numbers
+  if (groupBy === 'assignee') {
+    lines.push('');
+    lines.push('*Interpretation tip: High open counts per person may include backlog, review, and future-planned work — not just active tasks. Before reporting workload, break down by status: `metrics: ["summary"], groupBy: "issuetype"` scoped to one assignee to distinguish active work from queued/backlog items.*');
+  }
+
   return lines.join('\n');
 }
 
@@ -778,7 +784,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
   // If only summary requested, skip issue fetching entirely
   if (hasSummary && fetchMetrics.length === 0) {
     const summaryText = await handleSummary(jiraClient, jql, groupBy, compute, groupLimit);
-    const nextSteps = analysisNextSteps(jql, []);
+    const nextSteps = analysisNextSteps(jql, [], false, groupBy);
     return {
       content: [{
         type: 'text',
@@ -860,7 +866,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
   }
 
   // Next steps
-  const nextSteps = analysisNextSteps(jql, allIssues.slice(0, 3).map(i => i.key), truncated);
+  const nextSteps = analysisNextSteps(jql, allIssues.slice(0, 3).map(i => i.key), truncated, groupBy);
   lines.push(nextSteps);
 
   return {

--- a/src/utils/next-steps.ts
+++ b/src/utils/next-steps.ts
@@ -202,13 +202,30 @@ export function boardNextSteps(operation: string, boardId?: number): string {
   return steps.length > 0 ? formatSteps(steps) : '';
 }
 
-export function analysisNextSteps(jql: string, issueKeys: string[], truncated = false): string {
+export function analysisNextSteps(jql: string, issueKeys: string[], truncated = false, groupBy?: string): string {
   const steps: NextStep[] = [];
   if (issueKeys.length > 0) {
     steps.push(
       { description: 'Get details on a specific issue', tool: 'manage_jira_issue', example: { operation: 'get', issueKey: issueKeys[0] } },
     );
   }
+
+  // Contextual cross-dimension suggestions based on groupBy
+  if (groupBy === 'assignee') {
+    steps.push(
+      { description: 'Break down a person\'s workload by status (active vs backlog vs review)', tool: 'analyze_jira_issues', example: { jql: `${jql} AND assignee = "<name>"`, metrics: ['summary'], groupBy: 'issuetype' } },
+      { description: 'Compare workload health with computed metrics', tool: 'analyze_jira_issues', example: { jql, metrics: ['summary'], groupBy: 'assignee', compute: ['overdue_pct = overdue / open * 100', 'stale_pct = stale / open * 100'] } },
+    );
+  } else if (groupBy === 'issuetype' || groupBy === 'priority') {
+    steps.push(
+      { description: 'See who owns these issues', tool: 'analyze_jira_issues', example: { jql, metrics: ['summary'], groupBy: 'assignee' } },
+    );
+  } else if (groupBy === 'project') {
+    steps.push(
+      { description: 'Drill into a project by assignee', tool: 'analyze_jira_issues', example: { jql: `${jql} AND project = <KEY>`, metrics: ['summary'], groupBy: 'assignee' } },
+    );
+  }
+
   steps.push(
     { description: 'Discover dimensions for cube analysis', tool: 'analyze_jira_issues', example: { jql, metrics: ['cube_setup'] } },
     { description: 'Add computed columns', tool: 'analyze_jira_issues', example: { jql, metrics: ['summary'], groupBy: 'project', compute: ['bug_pct = bugs / total * 100'] } },


### PR DESCRIPTION
## Summary
- Adds interpretation tip to assignee-grouped summary output: "high open counts may include backlog/review/future work — break down by status before reporting"
- Next-steps are now contextual per groupBy dimension (assignee → status breakdown, project → assignee drill-down, etc.)

## Problem
When an LLM gets back "Lena: 580 total, 179 open" from a groupBy=assignee query, it reports the raw number without decomposing. A PM reading "179 open features" panics, but the reality is 22 in progress + 21 in review + 23 to do + 34 in backlog — very different from "179 active tasks."

## Test plan
- [x] `make check` passes (290 tests)
- [ ] Verify Claude Desktop proactively decomposes high workload numbers after rebuild