### PR TITLE
feat: history expand and groupBy project on implicit JQL

### DIFF
--- a/src/client/jira-client.ts
+++ b/src/client/jira-client.ts
@@ -173,6 +173,7 @@ export class JiraClient {
     includeComments = false,
     includeAttachments = false,
     customFieldMeta?: Array<{ id: string; name: string; type: string; description: string }>,
+    includeHistory = false,
   ): Promise<JiraIssueDetails> {
     const fields = [...this.issueFields];
 
@@ -189,14 +190,38 @@ export class JiraClient {
       }
     }
 
+    const expands: string[] = [];
+    if (includeComments) expands.push('comments');
+    if (includeHistory) expands.push('changelog');
+
     const params: any = {
       issueIdOrKey: issueKey,
       fields,
-      expand: includeComments ? 'comments' : undefined
+      expand: expands.length > 0 ? expands.join(',') : undefined,
     };
 
     const issue = await this.client.issues.getIssue(params);
     const issueDetails = this.mapIssueFields(issue);
+
+    // Extract status transitions from changelog
+    if (includeHistory && (issue as any).changelog?.histories) {
+      const histories = (issue as any).changelog.histories as Array<{
+        created: string;
+        author?: { displayName?: string };
+        items: Array<{ field: string; fromString: string | null; toString: string | null }>;
+      }>;
+      issueDetails.statusHistory = histories
+        .flatMap(h => h.items
+          .filter(item => item.field === 'status')
+          .map(item => ({
+            date: h.created,
+            from: item.fromString || '',
+            to: item.toString || '',
+            author: h.author?.displayName || 'Unknown',
+          }))
+        )
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    }
 
     // Extract custom field values using catalog metadata
     if (customFieldMeta) {

--- a/src/handlers/analysis-handler.ts
+++ b/src/handlers/analysis-handler.ts
@@ -525,11 +525,9 @@ async function handleSummary(jiraClient: JiraClient, jql: string, groupBy?: Grou
   // Effective group cap: user's preference vs API query budget (whichever is smaller)
   const effectiveGroupCap = Math.min(groupLimit, groupBudget);
 
-  if (groupBy === 'project') {
+  if (groupBy === 'project' && extractProjectKeys(jql).length > 0) {
+    // Fast path: project keys are explicit in JQL — no sampling needed
     let keys = extractProjectKeys(jql);
-    if (keys.length === 0) {
-      throw new McpError(ErrorCode.InvalidParams, 'groupBy "project" requires project keys in JQL (e.g., project in (AA, GC))');
-    }
     const capped = keys.length > effectiveGroupCap;
     if (capped) keys = keys.slice(0, effectiveGroupCap);
     const remaining = removeProjectClause(jql);

--- a/src/handlers/issue-handlers.ts
+++ b/src/handlers/issue-handlers.ts
@@ -300,11 +300,13 @@ async function handleGetIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs)
   // Get issue with requested expansions and catalog custom fields
   const includeComments = expansionOptions.comments || false;
   const includeAttachments = expansionOptions.attachments || false;
+  const includeHistory = expansionOptions.history || false;
   const issue = await jiraClient.getIssue(
     args.issueKey!,
     includeComments,
     includeAttachments,
     getCatalogFieldMeta(),
+    includeHistory,
   );
   
   // Get transitions if requested

--- a/src/mcp/markdown-renderer.ts
+++ b/src/mcp/markdown-renderer.ts
@@ -166,6 +166,21 @@ export function renderIssue(issue: JiraIssueDetails, transitions?: TransitionDet
     }
   }
 
+  // Status history (if requested via expand: ["history"])
+  if (issue.statusHistory && issue.statusHistory.length > 0) {
+    lines.push('');
+    lines.push('Status History:');
+    for (const h of issue.statusHistory) {
+      lines.push(`${formatDate(h.date)}: ${h.from} → ${h.to} (by ${h.author})`);
+    }
+    // Show time in current status
+    const last = issue.statusHistory[issue.statusHistory.length - 1];
+    const daysSince = Math.floor((Date.now() - new Date(last.date).getTime()) / (1000 * 60 * 60 * 24));
+    if (daysSince > 0) {
+      lines.push(`*In "${last.to}" for ${daysSince} days*`);
+    }
+  }
+
   // Available transitions
   if (transitions && transitions.length > 0) {
     lines.push('');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,12 @@ export interface JiraIssueDetails {
     description: string;
   }>;
   people?: JiraPerson[];
+  statusHistory?: Array<{
+    date: string;
+    from: string;
+    to: string;
+    author: string;
+  }>;
 }
 
 export interface HierarchyNode {


### PR DESCRIPTION
## Summary
- `expand: ["history"]` now actually works — returns status transition log with dates, from→to, author, and time-in-status
- `groupBy: "project"` no longer errors when JQL doesn't have explicit project keys (e.g., `portfolioChildIssuesOf()` queries)

## Problem
From the tool gap analysis report:
- **#2**: `groupBy: "project"` on Lena's issues threw "requires project keys in JQL" — tool failed completely
- **#3**: `expand: ["history"]` was listed as valid but silently returned nothing — no history or timestamps

## Test plan
- [x] `make check` passes (290 tests)
- [x] `expand: ["history"]` on AA-6453 returns: Backlog → To Do → In Progress → Request Review with dates
- [x] `groupBy: "project"` on `portfolioChildIssuesOf("IP-89") AND assignee = "Lena Zhukova"` returns AA: 141, IP: 38