### PR TITLE
feat: filter CRUD and queue usage hint

### DIFF
--- a/src/client/jira-client.ts
+++ b/src/client/jira-client.ts
@@ -1212,6 +1212,55 @@ export class JiraClient {
     return { key: response.key };
   }
 
+  async createFilter(name: string, jql: string, description?: string, favourite?: boolean): Promise<FilterResponse> {
+    const result = await this.client.filters.createFilter({
+      name,
+      jql,
+      description: description || '',
+      favourite: favourite ?? false,
+    });
+    if (!result.id || !result.name) {
+      throw new Error('Invalid filter response from Jira');
+    }
+    return {
+      id: result.id,
+      name: result.name,
+      owner: result.owner?.displayName || 'Unknown',
+      favourite: result.favourite || false,
+      viewUrl: result.viewUrl || '',
+      description: result.description || '',
+      jql: result.jql || '',
+    };
+  }
+
+  async updateFilter(filterId: string, updates: { name?: string; jql?: string; description?: string; favourite?: boolean }): Promise<FilterResponse> {
+    // Fetch existing filter to merge with updates (API requires name)
+    const existing = await this.client.filters.getFilter({ id: parseInt(filterId, 10) });
+    const result = await this.client.filters.updateFilter({
+      id: parseInt(filterId, 10),
+      name: updates.name || existing.name || '',
+      jql: updates.jql ?? existing.jql,
+      description: updates.description ?? existing.description,
+      favourite: updates.favourite ?? existing.favourite,
+    });
+    if (!result.id || !result.name) {
+      throw new Error('Invalid filter response from Jira');
+    }
+    return {
+      id: result.id,
+      name: result.name,
+      owner: result.owner?.displayName || 'Unknown',
+      favourite: result.favourite || false,
+      viewUrl: result.viewUrl || '',
+      description: result.description || '',
+      jql: result.jql || '',
+    };
+  }
+
+  async deleteFilter(filterId: string): Promise<void> {
+    await this.client.filters.deleteFilter(filterId);
+  }
+
   async listMyFilters(expand = false): Promise<FilterResponse[]> {
     const filters = await this.client.filters.getMyFilters();
     

--- a/src/handlers/filter-handlers.ts
+++ b/src/handlers/filter-handlers.ts
@@ -313,16 +313,69 @@ async function handleListFilters(jiraClient: JiraClient, args: ManageJiraFilterA
   };
 }
 
-async function handleCreateFilter(_jiraClient: JiraClient, _args: ManageJiraFilterArgs) {
-  throw new McpError(ErrorCode.InternalError, 'Create filter operation is not yet implemented');
+async function handleCreateFilter(jiraClient: JiraClient, args: ManageJiraFilterArgs) {
+  if (!args.name) {
+    throw new McpError(ErrorCode.InvalidParams, 'name is required for create operation');
+  }
+  if (!args.jql) {
+    throw new McpError(ErrorCode.InvalidParams, 'jql is required for create operation');
+  }
+
+  const filter = await jiraClient.createFilter(args.name, args.jql, args.description, args.favourite);
+
+  const lines = [
+    `# Filter Created: ${filter.name}`,
+    '',
+    `**ID:** ${filter.id}`,
+    `**JQL:** \`${filter.jql}\``,
+    `**Owner:** ${filter.owner}`,
+    filter.description ? `**Description:** ${filter.description}` : '',
+    `**Favourite:** ${filter.favourite ? 'Yes' : 'No'}`,
+    '',
+    `[View in Jira](${filter.viewUrl})`,
+  ].filter(Boolean);
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') + filterNextSteps('create', filter.id) }],
+  };
 }
 
-async function handleUpdateFilter(_jiraClient: JiraClient, _args: ManageJiraFilterArgs) {
-  throw new McpError(ErrorCode.InternalError, 'Update filter operation is not yet implemented');
+async function handleUpdateFilter(jiraClient: JiraClient, args: ManageJiraFilterArgs) {
+  if (!args.filterId) {
+    throw new McpError(ErrorCode.InvalidParams, 'filterId is required for update operation');
+  }
+
+  const updates: { name?: string; jql?: string; description?: string; favourite?: boolean } = {};
+  if (args.name) updates.name = args.name;
+  if (args.jql) updates.jql = args.jql;
+  if (args.description !== undefined) updates.description = args.description;
+  if (args.favourite !== undefined) updates.favourite = args.favourite;
+
+  const filter = await jiraClient.updateFilter(args.filterId, updates);
+
+  const lines = [
+    `# Filter Updated: ${filter.name}`,
+    '',
+    `**ID:** ${filter.id}`,
+    `**JQL:** \`${filter.jql}\``,
+    `**Owner:** ${filter.owner}`,
+  ];
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') + filterNextSteps('get', filter.id) }],
+  };
 }
 
-async function handleDeleteFilter(_jiraClient: JiraClient, _args: ManageJiraFilterArgs) {
-  throw new McpError(ErrorCode.InternalError, 'Delete filter operation is not yet implemented');
+async function handleDeleteFilter(jiraClient: JiraClient, args: ManageJiraFilterArgs) {
+  if (!args.filterId) {
+    throw new McpError(ErrorCode.InvalidParams, 'filterId is required for delete operation');
+  }
+
+  await jiraClient.deleteFilter(args.filterId);
+
+  return {
+    content: [{ type: 'text', text: `Filter ${args.filterId} deleted.` }],
+  };
 }
 
 async function handleExecuteFilter(jiraClient: JiraClient, _args: ManageJiraFilterArgs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,10 @@ class JiraServer {
       return getPrompt(name, args);
     });
 
+    // Track consecutive single-issue calls to suggest queue tool
+    const QUEUE_HINT_THRESHOLD = 3;
+    let consecutiveIssueCalls = 0;
+
     // Set up tool handlers
     this.server.setRequestHandler(CallToolRequestSchema, async (request, _extra) => {
       console.error('Received request:', JSON.stringify(request, null, 2));
@@ -155,6 +159,17 @@ class JiraServer {
         const response = await handler(this.jiraClient, request);
         if (!response) {
           throw new McpError(ErrorCode.InternalError, `No response from handler for tool: ${name}`);
+        }
+
+        // Track consecutive manage_jira_issue calls and suggest queue tool
+        if (name === 'manage_jira_issue') {
+          consecutiveIssueCalls++;
+          if (consecutiveIssueCalls >= QUEUE_HINT_THRESHOLD && response.content?.[0]?.text) {
+            response.content[0].text += `\n\n---\n**💡 Efficiency tip:** You've made ${consecutiveIssueCalls} consecutive \`manage_jira_issue\` calls. Consider using \`queue_jira_operations\` to batch multiple issue operations into a single call — it's faster and uses less context.`;
+            consecutiveIssueCalls = 0;
+          }
+        } else {
+          consecutiveIssueCalls = 0;
         }
 
         return response;


### PR DESCRIPTION
## Summary
- Implements filter create, update, and delete operations (previously stubbed as "not yet implemented")
- Adds consecutive-call tracking for `manage_jira_issue` — after 3+ calls in a row, suggests using `queue_jira_operations` to batch operations

## Test plan
- [x] `make check` passes (290 tests, lint, build)
- [ ] Test filter create/update/delete via Claude Desktop
- [ ] Verify queue hint appears after 3+ consecutive issue calls