### PR TITLE
feat: flow metric for status transition analysis

### DIFF
--- a/src/client/jira-client.ts
+++ b/src/client/jira-client.ts
@@ -137,6 +137,7 @@ export class JiraClient {
     }
 
     return {
+      id: issue.id,
       key: issue.key,
       summary: fields?.summary,
       description: fields?.description
@@ -483,6 +484,43 @@ export class JiraClient {
         author: attachment.author!.displayName!,
         url: attachment.content || '',
       }));
+  }
+
+  async getBulkChangelogs(issueKeys: string[], fieldIds: string[] = ['status']): Promise<Map<string, Array<{ date: string; from: string; to: string }>>> {
+    const result = new Map<string, Array<{ date: string; from: string; to: string }>>();
+
+    let nextPageToken: string | undefined;
+    do {
+      const response = await this.client.issues.getBulkChangelogs({
+        issueIdsOrKeys: issueKeys,
+        fieldIds,
+        maxResults: 1000,
+        nextPageToken,
+      });
+
+      for (const issueLog of response.issueChangeLogs || []) {
+        const issueId = issueLog.issueId;
+        if (!issueId) continue;
+
+        const transitions = result.get(issueId) || [];
+        for (const history of issueLog.changeHistories || []) {
+          for (const item of history.items || []) {
+            if (item.field === 'status') {
+              transitions.push({
+                date: history.created || '',
+                from: item.fromString || '',
+                to: item.toString || '',
+              });
+            }
+          }
+        }
+        result.set(issueId, transitions);
+      }
+
+      nextPageToken = response.nextPageToken ?? undefined;
+    } while (nextPageToken);
+
+    return result;
   }
 
   async getFilter(filterId: string): Promise<{ name?: string; jql?: string }> {

--- a/src/docs/tool-documentation.ts
+++ b/src/docs/tool-documentation.ts
@@ -539,6 +539,14 @@ function generateAnalysisToolDocumentation(schema: any) {
         ],
       },
       {
+        title: "Flow analysis — where do issues get stuck?",
+        description: "Analyze status transitions, time in status, and bounce patterns:",
+        steps: [
+          { description: "Flow metrics", code: { jql: "project = AA AND resolution = Unresolved", metrics: ["flow"] } },
+          { description: "Combined with summary", code: { jql: "project = AA", metrics: ["summary", "flow"], groupBy: "issuetype" } },
+        ],
+      },
+      {
         title: "Data cube — discover then compute",
         description: "Two-phase analysis with computed columns:",
         steps: [

--- a/src/handlers/analysis-handler.ts
+++ b/src/handlers/analysis-handler.ts
@@ -8,9 +8,10 @@ import { normalizeArgs } from '../utils/normalize-args.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-type MetricGroup = 'points' | 'time' | 'schedule' | 'cycle' | 'distribution' | 'summary' | 'cube_setup';
+type MetricGroup = 'points' | 'time' | 'schedule' | 'cycle' | 'distribution' | 'flow' | 'summary' | 'cube_setup';
 
 const ALL_METRICS: MetricGroup[] = ['points', 'time', 'schedule', 'cycle', 'distribution'];
+// flow is opt-in only — requires extra bulk changelog API call
 const VALID_GROUP_BY = ['project', 'assignee', 'priority', 'issuetype'] as const;
 type GroupByField = typeof VALID_GROUP_BY[number];
 const MAX_ISSUES_HARD = 500;   // absolute ceiling for detail metrics — beyond this, context explodes
@@ -328,6 +329,127 @@ export function renderDistribution(issues: JiraIssueDetails[], groupLimit = DEFA
 
   const byType = countBy(issues, i => i.issueType || 'Unknown');
   lines.push(`**By type:** ${mapToString(byType, ' | ', groupLimit)}`);
+
+  return lines.join('\n');
+}
+
+// ── Flow (bulk changelog) ─────────────────────────────────────────────
+
+interface StatusFlowStats {
+  status: string;
+  entries: number;       // how many times issues entered this status
+  totalDaysIn: number;   // total days spent across all visits
+  issueCount: number;    // distinct issues that visited this status
+  bounces: number;       // re-entries (entered more than once by same issue)
+}
+
+export async function renderFlow(jiraClient: JiraClient, issues: JiraIssueDetails[]): Promise<string> {
+  if (issues.length === 0) return '## Flow\n\nNo issues to analyze.';
+
+  const issueKeys = issues.map(i => i.key);
+  // Build a map of issue key → issue ID for matching bulk response
+  const keyToId = new Map<string, string>();
+  const idToKey = new Map<string, string>();
+  for (const issue of issues) {
+    if (issue.id) {
+      keyToId.set(issue.key, issue.id);
+      idToKey.set(issue.id, issue.key);
+    }
+  }
+
+  const changelogs = await jiraClient.getBulkChangelogs(issueKeys);
+
+  // Aggregate per-status stats
+  const statusStats = new Map<string, StatusFlowStats>();
+  const issueBounceCounts = new Map<string, Map<string, number>>(); // issueId → status → entry count
+  let totalTransitions = 0;
+
+  for (const [issueId, transitions] of changelogs) {
+    if (transitions.length === 0) continue;
+    totalTransitions += transitions.length;
+
+    // Sort transitions by date
+    const sorted = [...transitions].sort((a, b) =>
+      new Date(a.date).getTime() - new Date(b.date).getTime()
+    );
+
+    // Track entries per status for this issue
+    const issueStatusEntries = new Map<string, number>();
+
+    for (let i = 0; i < sorted.length; i++) {
+      const t = sorted[i];
+      const toStatus = t.to;
+
+      // Count entries into the target status
+      issueStatusEntries.set(toStatus, (issueStatusEntries.get(toStatus) || 0) + 1);
+
+      // Calculate time spent in the target status
+      const enteredAt = new Date(t.date).getTime();
+      const exitedAt = i + 1 < sorted.length
+        ? new Date(sorted[i + 1].date).getTime()
+        : Date.now();
+      const daysIn = (exitedAt - enteredAt) / (1000 * 60 * 60 * 24);
+
+      const stats = statusStats.get(toStatus) || { status: toStatus, entries: 0, totalDaysIn: 0, issueCount: 0, bounces: 0 };
+      stats.entries++;
+      stats.totalDaysIn += daysIn;
+      statusStats.set(toStatus, stats);
+    }
+
+    issueBounceCounts.set(issueId, issueStatusEntries);
+  }
+
+  // Count distinct issues and bounces per status
+  const issuesPerStatus = new Map<string, Set<string>>();
+  for (const [issueId, statusEntries] of issueBounceCounts) {
+    for (const [status, count] of statusEntries) {
+      if (!issuesPerStatus.has(status)) issuesPerStatus.set(status, new Set());
+      issuesPerStatus.get(status)!.add(issueId);
+
+      const stats = statusStats.get(status);
+      if (stats && count > 1) {
+        stats.bounces += count - 1;
+      }
+    }
+  }
+  for (const [status, issueSet] of issuesPerStatus) {
+    const stats = statusStats.get(status);
+    if (stats) stats.issueCount = issueSet.size;
+  }
+
+  if (statusStats.size === 0) {
+    return '## Flow\n\nNo status transitions found in these issues.';
+  }
+
+  // Render table
+  const lines = ['## Flow (Status Transitions)', ''];
+  lines.push(`${totalTransitions} transitions across ${changelogs.size} issues`);
+  lines.push('');
+  lines.push('| Status | Entries | Avg days in | Bounce rate | Issues |');
+  lines.push('|--------|--------:|------------:|------------:|-------:|');
+
+  const sorted = [...statusStats.values()].sort((a, b) => b.entries - a.entries);
+  for (const s of sorted) {
+    const avgDays = s.entries > 0 ? (s.totalDaysIn / s.entries).toFixed(1) : '—';
+    const bounceRate = s.issueCount > 0 ? Math.round((s.bounces / s.issueCount) * 100) : 0;
+    lines.push(`| ${s.status} | ${s.entries} | ${avgDays} | ${bounceRate}% | ${s.issueCount} |`);
+  }
+
+  // Top bouncers — issues with most re-entries to any status
+  const bouncerScores: Array<{ key: string; bounces: number }> = [];
+  for (const [issueId, statusEntries] of issueBounceCounts) {
+    const totalBounces = [...statusEntries.values()].reduce((sum, count) => sum + Math.max(0, count - 1), 0);
+    if (totalBounces > 0) {
+      const key = idToKey.get(issueId) || issueId;
+      bouncerScores.push({ key, bounces: totalBounces });
+    }
+  }
+  if (bouncerScores.length > 0) {
+    bouncerScores.sort((a, b) => b.bounces - a.bounces);
+    const top = bouncerScores.slice(0, 5);
+    lines.push('');
+    lines.push(`**Top bouncers:** ${top.map(b => `${b.key} (${b.bounces}×)`).join(', ')}`);
+  }
 
   return lines.join('\n');
 }
@@ -766,9 +888,12 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
     : [];
   const hasSummary = requested.includes('summary');
   const hasCubeSetup = requested.includes('cube_setup');
+  const hasFlow = requested.includes('flow');
   const fetchMetrics = requested.length > 0
     ? requested.filter(m => ALL_METRICS.includes(m as MetricGroup)) as MetricGroup[]
     : ALL_METRICS;
+  // flow needs issue fetching but isn't in ALL_METRICS (opt-in only)
+  const needsIssueFetch = fetchMetrics.length > 0 || hasFlow;
 
   // Parse groupBy
   const groupBy = (typeof args.groupBy === 'string' && VALID_GROUP_BY.includes(args.groupBy as GroupByField))
@@ -798,8 +923,8 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
     };
   }
 
-  // If only summary requested, skip issue fetching entirely
-  if (hasSummary && fetchMetrics.length === 0) {
+  // If only summary requested (no flow or detail metrics), skip issue fetching entirely
+  if (hasSummary && !needsIssueFetch) {
     const summaryText = await handleSummary(jiraClient, jql, groupBy, compute, groupLimit);
     const nextSteps = analysisNextSteps(jql, [], false, groupBy, filterSource);
     const banner = filterSource ? `*Using saved filter: ${filterSource}*\n\n` : '';
@@ -865,7 +990,7 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
   }
 
   // Header for fetch-based metrics
-  if (fetchMetrics.length > 0 && allIssues.length > 0) {
+  if ((fetchMetrics.length > 0 || hasFlow) && allIssues.length > 0) {
     if (hasSummary) lines.push('');
     lines.push(`# Detail: ${jql}`);
     lines.push(`Analyzed ${allIssues.length} issues (as of ${formatDateShort(now)})`);
@@ -886,6 +1011,12 @@ export async function handleAnalysisRequest(jiraClient: JiraClient, request: any
       lines.push('');
       lines.push(renderers[metric]());
     }
+  }
+
+  // Flow is opt-in and requires async bulk changelog fetch
+  if (hasFlow && allIssues.length > 0) {
+    lines.push('');
+    lines.push(await renderFlow(jiraClient, allIssues));
   }
 
   // Next steps

--- a/src/prompts/prompt-messages.ts
+++ b/src/prompts/prompt-messages.ts
@@ -35,8 +35,8 @@ Operation 0 — Save the query as a reusable filter:
 Operation 1 — Summary with data quality signals (uses $0.filterId):
 {"tool":"analyze_jira_issues","args":{"filterId":"$0.filterId","metrics":["summary"],"groupBy":"priority","compute":["rot_pct = backlog_rot / open * 100","stale_pct = stale / open * 100","gap_pct = no_estimate / open * 100"]}}
 
-Operation 2 — Cycle metrics for staleness distribution:
-{"tool":"analyze_jira_issues","args":{"filterId":"$0.filterId","metrics":["cycle"],"maxResults":100}}
+Operation 2 — Flow analysis for transition patterns and bottlenecks:
+{"tool":"analyze_jira_issues","args":{"filterId":"$0.filterId","metrics":["flow"],"maxResults":100}}
 
 After the pipeline completes, summarize findings:
 - What percentage of the backlog is rotting (no owner, no dates, untouched)?

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -332,7 +332,7 @@ export const toolSchemas = {
 
   analyze_jira_issues: {
     name: 'analyze_jira_issues',
-    description: 'Compute project metrics over issues selected by JQL or a saved filter. For counting and breakdown questions ("how many by status/assignee/priority"), use metrics: ["summary"] with groupBy — this gives exact counts with no issue cap. Use detail metrics (points, time, schedule, cycle, distribution) only when you need per-issue analysis; these are capped at maxResults issues. Always prefer this tool over manage_jira_filter or manage_jira_project for quantitative questions. Tip: save complex JQL as a filter with manage_jira_filter, then reuse the filterId here for repeated analysis. Read jira://analysis/recipes for composition patterns.',
+    description: 'Compute project metrics over issues selected by JQL or a saved filter. For counting and breakdown questions ("how many by status/assignee/priority"), use metrics: ["summary"] with groupBy — this gives exact counts with no issue cap. Use detail metrics (points, time, schedule, cycle, distribution) for per-issue analysis (capped at maxResults). Use flow for status transition patterns — how issues move through statuses, where they bounce, and how long they stay. Tip: save complex JQL as a filter with manage_jira_filter, then reuse the filterId here for repeated analysis. Read jira://analysis/recipes for composition patterns.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -348,9 +348,9 @@ export const toolSchemas = {
           type: 'array',
           items: {
             type: 'string',
-            enum: ['summary', 'points', 'time', 'schedule', 'cycle', 'distribution', 'cube_setup'],
+            enum: ['summary', 'points', 'time', 'schedule', 'cycle', 'distribution', 'flow', 'cube_setup'],
           },
-          description: 'Which metric groups to compute. summary = exact counts via count API (no issue cap, fastest) — use with groupBy for "how many by assignee/status/priority" questions. distribution = approximate counts from fetched issues (capped by maxResults — use summary + groupBy instead when you need exact counts). cube_setup = discover dimensions before cube queries. points = earned value/SPI. time = effort estimates. schedule = overdue/risk. cycle = lead time/throughput. Default: all detail metrics. For counting/breakdown questions, always prefer summary + groupBy over distribution.',
+          description: 'Which metric groups to compute. summary = exact counts via count API (no issue cap, fastest) — use with groupBy for "how many by assignee/status/priority" questions. distribution = approximate counts from fetched issues (capped by maxResults — use summary + groupBy instead when you need exact counts). flow = status transition analysis from bulk changelogs — entries per status, avg time in each, bounce rates, top bouncers. cube_setup = discover dimensions before cube queries. points = earned value/SPI. time = effort estimates. schedule = overdue/risk. cycle = lead time/throughput. Default: all detail metrics (excluding flow — request flow explicitly). For counting/breakdown questions, always prefer summary + groupBy over distribution.',
         },
         groupBy: {
           type: 'string',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export interface JiraPerson {
 }
 
 export interface JiraIssueDetails {
+  id?: string;
   key: string;
   summary: string;
   description: string;


### PR DESCRIPTION
## Summary
- Adds `flow` metric to `analyze_jira_issues` — bulk-fetches status changelogs via `POST /changelog/bulkfetch` (1-2 API calls for up to 1000 issues)
- Computes entries per status, avg days in each, bounce rate (re-entries), and identifies top bouncer issues
- Opt-in only (`metrics: ["flow"]`) — not included in default metric set since it requires extra API calls

## Test plan
- [x] `make check` passes (290 tests)
- [x] Tested live: 355 transitions across 98 issues under IP-89 descendants
- [x] Verified bounce detection (QRM-249 at 6×)
- [x] Verified flow renders correctly alongside other metrics