### PR TITLE
feat: attachment and workspace management (ADR-211)

### DIFF
--- a/docs/architecture/tools/ADR-211-attachment-and-workspace-management.md
+++ b/docs/architecture/tools/ADR-211-attachment-and-workspace-management.md
@@ -1,0 +1,191 @@
+---
+status: Draft
+date: 2026-03-27
+deciders:
+  - aaronsb
+related:
+  - ADR-200
+  - ADR-203
+---
+
+# ADR-211: Attachment and Workspace Management
+
+## Context
+
+Jira issues support file attachments (screenshots, logs, documents, exports), but the MCP server currently has no way to interact with them. The `manage_jira_issue` tool can expand `attachments` in a `get` response, but there are no operations to upload, download, or manage attachment files.
+
+This is a gap for several workflows:
+
+- **Bug triage**: Viewing screenshots or log files attached to issues
+- **Documentation**: Attaching design documents, specs, or exports to issues
+- **Cross-issue operations**: Copying attachments between issues (download from one, upload to another)
+- **Report generation**: Attaching generated reports or charts to issues for stakeholder consumption
+
+### Multi-step file operations require staging
+
+MCP tool calls are stateless — there is no way to hold binary content between calls. Without a staging area:
+
+- Download returns metadata but there is nowhere to persist the bytes for a subsequent upload
+- Upload requires base64 content in the tool call, which means the LLM must hold binary data in context
+- Multi-step flows (download → process → upload) are impossible
+
+### Proven pattern: confluence-cloud workspace
+
+The `confluence-cloud` MCP server (ADR-502) solved this with an XDG-compliant workspace directory that sandboxes all file operations:
+
+- Default path: `~/.local/share/{app-name}/workspace/`
+- Configurable via `WORKSPACE_DIR` environment variable
+- Security sandbox: path traversal prevention, symlink escape detection, forbidden path validation
+- Two tools: `manage_confluence_media` (attachment CRUD) + `manage_workspace` (local file staging)
+
+Both servers are Atlassian REST API clients with the same authentication model. The Jira attachment API surface is similar to Confluence's. Patterning closely reduces implementation risk and maintains consistency across the MCP server family.
+
+### Jira attachment API
+
+Jira Cloud v3 REST API provides:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/rest/api/3/issue/{issueKey}?fields=attachment` | GET | List attachments on an issue |
+| `/rest/api/3/attachment/{id}` | GET | Get attachment metadata |
+| `/rest/api/3/attachment/content/{id}` | GET | Download attachment content |
+| `/rest/api/3/issue/{issueKey}/attachments` | POST | Upload attachment (multipart) |
+| `/rest/api/3/attachment/{id}` | DELETE | Delete attachment |
+
+The upload endpoint requires the `X-Atlassian-Token: no-check` header to bypass XSRF protection.
+
+## Decision
+
+Add two new tools — `manage_jira_media` and `manage_workspace` — following the confluence-cloud pattern (ADR-502).
+
+### Tool 1: `manage_jira_media`
+
+Attachment CRUD operations on Jira issues.
+
+| Operation | Required Args | Optional Args | Effect |
+|-----------|---------------|---------------|--------|
+| `list` | `issueKey` | — | List attachments on an issue |
+| `upload` | `issueKey`, `filename`, `mediaType` | `content` (base64) OR `workspaceFile` | Upload file to issue |
+| `download` | `attachmentId` | `filename` | Download attachment to workspace |
+| `view` | `attachmentId` | — | Display image inline (5MB limit) |
+| `get_info` | `attachmentId` | — | Fetch attachment metadata |
+| `delete` | `attachmentId` | — | Remove attachment |
+
+Key design points:
+
+- **`issueKey` not `pageId`**: Jira attaches files to issues, not pages. This is the only schema difference from confluence-cloud's `manage_confluence_media`.
+- **Upload dual-source**: Accepts either `content` (base64-encoded) for direct upload or `workspaceFile` (filename in workspace) for staged uploads. Same pattern as confluence-cloud.
+- **Download writes to workspace**: Returns absolute path and suggests next actions (view, upload to another issue, delete).
+- **View returns image content**: For image attachments under 5MB, returns inline `image` content block. Non-images or oversized files return metadata with guidance to download instead.
+
+### Tool 2: `manage_workspace`
+
+Local file staging in an XDG-compliant sandbox. Identical interface to confluence-cloud's `manage_workspace`.
+
+| Operation | Required Args | Optional Args | Effect |
+|-----------|---------------|---------------|--------|
+| `list` | — | — | List staged files with sizes and timestamps |
+| `read` | `filename` | — | Return file content (inline for text <100KB or images <5MB, path reference otherwise) |
+| `write` | `filename`, `content` | — | Write base64-encoded content to workspace |
+| `delete` | `filename` | — | Remove file or directory |
+| `mkdir` | `filename` | — | Create directory |
+| `move` | `filename`, `destination` | — | Rename or relocate file |
+
+### Workspace directory
+
+```
+~/.local/share/jira-cloud-mcp/
+  workspace/          <- staging area for file operations
+```
+
+- `$XDG_DATA_HOME/jira-cloud-mcp/workspace/` if `XDG_DATA_HOME` is set
+- `~/.local/share/jira-cloud-mcp/workspace/` otherwise
+- `$WORKSPACE_DIR` overrides everything if set
+
+### Security sandbox
+
+Directly ported from confluence-cloud:
+
+1. **Path traversal prevention**: Filenames sanitized (no `../`, no path separators, no null bytes). Resolved paths must remain within workspace.
+2. **Symlink escape detection**: `fs.realpath()` post-resolution verifies actual path is within workspace.
+3. **Forbidden paths**: Workspace cannot be home directory, `~/Documents`, `~/Downloads`, `~/Desktop`, cloud sync mounts, or filesystem root.
+4. **Lazy creation**: Workspace directory created on first use with `recursive: true` and `0o755`.
+
+### Queue integration
+
+Both new tools are added to the `queue_jira_operations` tool enum, enabling pipelines like:
+
+```
+queue_jira_operations:
+  1. manage_jira_filter execute_jql "project = PROJ AND attachments IS NOT EMPTY"
+  2. manage_jira_media list issueKey: $0.issues[0].key
+```
+
+### Next-steps integration
+
+Following existing bidirectional steering patterns:
+
+- `manage_jira_issue get` (with attachments expanded) → suggests `manage_jira_media` for attachment operations
+- `manage_jira_media download` → suggests `manage_workspace read` or `manage_jira_media upload`
+- `manage_workspace list` → suggests `manage_jira_media upload` for staged files
+
+### Code organization
+
+```
+src/
+  workspace/
+    workspace.ts        <- XDG paths, sandbox, sanitization (port from confluence-cloud)
+    index.ts            <- exports
+  handlers/
+    media-handler.ts    <- manage_jira_media operations
+    workspace-handler.ts <- manage_workspace operations
+  schemas/
+    tool-schemas.ts     <- add manage_jira_media + manage_workspace schemas
+```
+
+The `workspace/` module is a near-verbatim port from confluence-cloud with `APP_NAME = 'jira-cloud-mcp'` as the only change. The media handler adapts the confluence-cloud pattern to Jira's attachment API endpoints.
+
+### Client methods
+
+New methods on `JiraClient`:
+
+```typescript
+getAttachments(issueKey: string): Promise<Attachment[]>
+getAttachmentInfo(id: string): Promise<Attachment>
+downloadAttachment(id: string): Promise<Buffer>
+uploadAttachment(issueKey: string, filename: string, content: Buffer, mediaType: string): Promise<Attachment>
+deleteAttachment(id: string): Promise<void>
+```
+
+## Consequences
+
+### Positive
+
+- Enables attachment workflows that are currently impossible (upload, download, cross-issue copy)
+- Consistent interface with confluence-cloud — agents working across both servers use the same patterns
+- Workspace sandbox prevents accidental filesystem operations outside the jail
+- Queue integration enables attachment pipelines
+- XDG compliance gives predictable, user-configurable paths
+
+### Negative
+
+- Two new tools increases tool count from 8 to 10 — still within discoverable range per ADR-200
+- Server now writes to the local filesystem — must handle permissions, disk space
+- Workspace files persist between sessions unless explicitly deleted
+
+### Neutral
+
+- The workspace is optional — base64 upload works without it
+- `manage_jira_issue get` with `expand: ["attachments"]` continues to work for read-only attachment listing
+- File size limits should match Jira's configured attachment size limits
+- The workspace directory persists across MCP server restarts
+
+## Alternatives Considered
+
+- **Add attachment operations to `manage_jira_issue`**: Would keep tool count at 8, but `manage_jira_issue` already has 10 operations and would grow to 16. This violates ADR-200's principle of keeping tools focused. The attachment lifecycle (upload, download, view, stage) is distinct from issue lifecycle (create, update, transition). Rejected.
+
+- **Media tool without workspace**: Upload requires base64 in the tool call, download returns metadata only. Functional for single-step operations but cannot bridge download → upload across tool calls. The LLM would need to hold binary content in context. Rejected — same reasoning as confluence-cloud ADR-502.
+
+- **In-memory file staging**: Store downloaded files in server memory. Simpler, but memory-constrained and lost on restart. Does not work for large files or across sessions. Rejected.
+
+- **Shared workspace package**: Extract workspace module as a shared npm package used by both confluence-cloud and jira-cloud. Good long-term goal, but premature — start with a direct port and extract if a third consumer appears. Deferred.

--- a/src/client/jira-client.ts
+++ b/src/client/jira-client.ts
@@ -1360,6 +1360,58 @@ export class JiraClient {
     };
   }
 
+  // ── Attachment Operations ────────────────────────────────
+
+  async getAttachmentInfo(attachmentId: string): Promise<JiraAttachment> {
+    const meta = await this.client.issueAttachments.getAttachment(attachmentId);
+    return {
+      id: meta.id?.toString() ?? attachmentId,
+      filename: meta.filename ?? 'unnamed',
+      mimeType: meta.mimeType ?? 'application/octet-stream',
+      size: meta.size ?? 0,
+      created: meta.created ?? '',
+      author: meta.author?.displayName ?? 'Unknown',
+      url: meta.content ?? '',
+    };
+  }
+
+  async downloadAttachment(attachmentId: string): Promise<Buffer> {
+    const content = await this.client.issueAttachments.getAttachmentContent(attachmentId);
+    // jira.js generic defaults to Buffer; ensure we return Buffer even if runtime type differs
+    return Buffer.isBuffer(content) ? content : Buffer.from(content as any);
+  }
+
+  async uploadAttachment(
+    issueKey: string,
+    filename: string,
+    content: Buffer,
+    mimeType: string,
+  ): Promise<JiraAttachment> {
+    const result = await this.client.issueAttachments.addAttachment({
+      issueIdOrKey: issueKey,
+      attachment: {
+        filename,
+        file: content,
+        mimeType,
+      },
+    });
+
+    const att = Array.isArray(result) ? result[0] : result;
+    return {
+      id: att.id?.toString() ?? '',
+      filename: att.filename ?? filename,
+      mimeType: att.mimeType ?? mimeType,
+      size: att.size ?? content.length,
+      created: att.created ?? new Date().toISOString(),
+      author: att.author?.displayName ?? 'Unknown',
+      url: att.content ?? '',
+    };
+  }
+
+  async deleteAttachment(attachmentId: string): Promise<void> {
+    await this.client.issueAttachments.removeAttachment(attachmentId);
+  }
+
   async deleteFilter(filterId: string): Promise<void> {
     await this.client.filters.deleteFilter(filterId);
   }

--- a/src/handlers/media-handler.test.ts
+++ b/src/handlers/media-handler.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleMediaRequest } from './media-handler.js';
+
+// Mock workspace module to avoid filesystem side effects
+vi.mock('../workspace/index.js', () => ({
+  ensureWorkspaceDir: vi.fn().mockResolvedValue({ path: '/mock/workspace', valid: true }),
+  resolveWorkspacePath: vi.fn((f: string) => `/mock/workspace/${f}`),
+  ensureParentDir: vi.fn().mockResolvedValue(undefined),
+  verifyPathSafety: vi.fn().mockResolvedValue(undefined),
+  sanitizeFilename: vi.fn((f: string) => f),
+}));
+
+// Mock fs to avoid real filesystem operations
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn().mockResolvedValue(Buffer.from('fake content')),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+function mockClient(overrides: Record<string, any> = {}) {
+  return {
+    getIssueAttachments: overrides.getIssueAttachments ?? vi.fn().mockResolvedValue([
+      { id: '100', filename: 'test.png', mimeType: 'image/png', size: 1024, created: '2026-01-01', author: 'Test User', url: '' },
+      { id: '101', filename: 'doc.pdf', mimeType: 'application/pdf', size: 2048, created: '2026-01-02', author: 'Test User', url: '' },
+    ]),
+    getAttachmentInfo: overrides.getAttachmentInfo ?? vi.fn().mockResolvedValue(
+      { id: '100', filename: 'test.png', mimeType: 'image/png', size: 1024, created: '2026-01-01', author: 'Test User', url: '' },
+    ),
+    downloadAttachment: overrides.downloadAttachment ?? vi.fn().mockResolvedValue(Buffer.from('fake image bytes')),
+    uploadAttachment: overrides.uploadAttachment ?? vi.fn().mockResolvedValue(
+      { id: '200', filename: 'uploaded.png', mimeType: 'image/png', size: 512, created: '2026-01-03', author: 'Test User', url: '' },
+    ),
+    deleteAttachment: overrides.deleteAttachment ?? vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+describe('media-handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list', () => {
+    it('requires issueKey', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'list' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('issueKey is required');
+    });
+
+    it('lists attachments on an issue', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'list', issueKey: 'PROJ-1' });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('test.png');
+      expect(result.content[0].text).toContain('doc.pdf');
+      expect(result.content[0].text).toContain('Attachments on PROJ-1 (2)');
+    });
+
+    it('reports empty attachments', async () => {
+      const client = mockClient({ getIssueAttachments: vi.fn().mockResolvedValue([]) });
+      const result = await handleMediaRequest(client, { operation: 'list', issueKey: 'PROJ-1' });
+      expect(result.content[0].text).toContain('No attachments');
+    });
+  });
+
+  describe('upload', () => {
+    it('requires issueKey, filename, and mediaType', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'upload' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('issueKey, filename, and mediaType are required');
+    });
+
+    it('requires content or workspaceFile', async () => {
+      const result = await handleMediaRequest(mockClient(), {
+        operation: 'upload', issueKey: 'PROJ-1', filename: 'test.png', mediaType: 'image/png',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Either content (base64) or workspaceFile');
+    });
+
+    it('uploads from base64 content', async () => {
+      const client = mockClient();
+      const result = await handleMediaRequest(client, {
+        operation: 'upload', issueKey: 'PROJ-1', filename: 'test.png',
+        mediaType: 'image/png', content: Buffer.from('fake').toString('base64'),
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Uploaded');
+      expect(client.uploadAttachment).toHaveBeenCalledWith('PROJ-1', 'test.png', expect.any(Buffer), 'image/png');
+    });
+
+    it('uploads from workspace file', async () => {
+      const client = mockClient();
+      const result = await handleMediaRequest(client, {
+        operation: 'upload', issueKey: 'PROJ-1', filename: 'test.png',
+        mediaType: 'image/png', workspaceFile: 'test.png',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Uploaded');
+    });
+  });
+
+  describe('download', () => {
+    it('requires attachmentId', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'download' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('attachmentId is required');
+    });
+
+    it('downloads to workspace', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'download', attachmentId: '100' });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Downloaded');
+      expect(result.content[0].text).toContain('/mock/workspace/');
+      expect(result.content[0].text).toContain('manage_workspace read');
+    });
+
+    it('respects filename override', async () => {
+      const result = await handleMediaRequest(mockClient(), {
+        operation: 'download', attachmentId: '100', filename: 'custom-name.png',
+      });
+      expect(result.content[0].text).toContain('custom-name.png');
+    });
+
+    it('fails when workspace is invalid', async () => {
+      const { ensureWorkspaceDir } = await import('../workspace/index.js');
+      vi.mocked(ensureWorkspaceDir).mockResolvedValueOnce({ path: '/bad', valid: false, warning: 'forbidden' });
+      const result = await handleMediaRequest(mockClient(), { operation: 'download', attachmentId: '100' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Workspace invalid');
+    });
+  });
+
+  describe('view', () => {
+    it('requires attachmentId', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'view' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns inline image for small images', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'view', attachmentId: '100' });
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toContain('test.png');
+      expect(result.content[1].type).toBe('image');
+      expect(result.content[1].mimeType).toBe('image/png');
+    });
+
+    it('rejects non-image files', async () => {
+      const client = mockClient({
+        getAttachmentInfo: vi.fn().mockResolvedValue(
+          { id: '101', filename: 'doc.pdf', mimeType: 'application/pdf', size: 1024, created: '', author: '', url: '' },
+        ),
+      });
+      const result = await handleMediaRequest(client, { operation: 'view', attachmentId: '101' });
+      expect(result.content[0].text).toContain('Not an image');
+      expect(result.content[0].text).toContain('download');
+    });
+
+    it('rejects oversized images', async () => {
+      const client = mockClient({
+        getAttachmentInfo: vi.fn().mockResolvedValue(
+          { id: '100', filename: 'huge.png', mimeType: 'image/png', size: 10 * 1024 * 1024, created: '', author: '', url: '' },
+        ),
+      });
+      const result = await handleMediaRequest(client, { operation: 'view', attachmentId: '100' });
+      expect(result.content[0].text).toContain('too large');
+    });
+  });
+
+  describe('get_info', () => {
+    it('requires attachmentId', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'get_info' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns attachment metadata', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'get_info', attachmentId: '100' });
+      expect(result.content[0].text).toContain('test.png');
+      expect(result.content[0].text).toContain('image/png');
+      expect(result.content[0].text).toContain('id:100');
+    });
+  });
+
+  describe('delete', () => {
+    it('requires attachmentId', async () => {
+      const result = await handleMediaRequest(mockClient(), { operation: 'delete' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('deletes and confirms permanence', async () => {
+      const client = mockClient();
+      const result = await handleMediaRequest(client, { operation: 'delete', attachmentId: '100' });
+      expect(result.content[0].text).toContain('Permanently deleted');
+      expect(result.content[0].text).toContain('cannot be undone');
+      expect(client.deleteAttachment).toHaveBeenCalledWith('100');
+    });
+  });
+
+  it('rejects unknown operations', async () => {
+    const result = await handleMediaRequest(mockClient(), { operation: 'explode' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Unknown media operation');
+  });
+});

--- a/src/handlers/media-handler.test.ts
+++ b/src/handlers/media-handler.test.ts
@@ -4,6 +4,11 @@ import { handleMediaRequest } from './media-handler.js';
 // Mock workspace module to avoid filesystem side effects
 vi.mock('../workspace/index.js', () => ({
   ensureWorkspaceDir: vi.fn().mockResolvedValue({ path: '/mock/workspace', valid: true }),
+  formatSize: (bytes: number) => {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  },
   resolveWorkspacePath: vi.fn((f: string) => `/mock/workspace/${f}`),
   ensureParentDir: vi.fn().mockResolvedValue(undefined),
   verifyPathSafety: vi.fn().mockResolvedValue(undefined),

--- a/src/handlers/media-handler.ts
+++ b/src/handlers/media-handler.ts
@@ -1,0 +1,168 @@
+/**
+ * Handler for manage_jira_media tool.
+ * See ADR-211: Attachment and Workspace Management.
+ */
+
+import * as fs from 'node:fs/promises';
+
+import type { JiraClient } from '../client/jira-client.js';
+import { mediaNextSteps } from '../utils/next-steps.js';
+import {
+  ensureWorkspaceDir,
+  resolveWorkspacePath,
+  ensureParentDir,
+  verifyPathSafety,
+  sanitizeFilename,
+} from '../workspace/index.js';
+
+interface MediaArgs {
+  operation: string;
+  issueKey?: string;
+  attachmentId?: string;
+  filename?: string;
+  content?: string;
+  mediaType?: string;
+  workspaceFile?: string;
+}
+
+export async function handleMediaRequest(
+  client: JiraClient,
+  args: MediaArgs,
+): Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }> {
+  switch (args.operation) {
+    case 'list': {
+      if (!args.issueKey) {
+        return { content: [{ type: 'text', text: 'issueKey is required for list operation' }], isError: true };
+      }
+      const attachments = await client.getIssueAttachments(args.issueKey);
+      if (attachments.length === 0) {
+        let text = `No attachments on ${args.issueKey}.`;
+        text += mediaNextSteps('list', { issueKey: args.issueKey });
+        return { content: [{ type: 'text', text }] };
+      }
+      const lines = attachments.map(a =>
+        `- ${a.filename} | ${a.mimeType} | ${formatSize(a.size)} | id:${a.id} | ${a.author} | ${a.created}`,
+      );
+      let text = `Attachments on ${args.issueKey} (${attachments.length}):\n${lines.join('\n')}`;
+      text += mediaNextSteps('list', { issueKey: args.issueKey });
+      return { content: [{ type: 'text', text }] };
+    }
+
+    case 'upload': {
+      if (!args.issueKey || !args.filename || !args.mediaType) {
+        return {
+          content: [{ type: 'text', text: 'issueKey, filename, and mediaType are required for upload' }],
+          isError: true,
+        };
+      }
+
+      let buffer: Buffer;
+      if (args.workspaceFile) {
+        const filePath = resolveWorkspacePath(args.workspaceFile);
+        await verifyPathSafety(filePath);
+        try {
+          buffer = await fs.readFile(filePath);
+        } catch {
+          return { content: [{ type: 'text', text: `Workspace file not found: ${args.workspaceFile}` }], isError: true };
+        }
+      } else if (args.content) {
+        buffer = Buffer.from(args.content, 'base64');
+      } else {
+        return {
+          content: [{ type: 'text', text: 'Either content (base64) or workspaceFile is required for upload' }],
+          isError: true,
+        };
+      }
+
+      const attachment = await client.uploadAttachment(args.issueKey, args.filename, buffer, args.mediaType);
+      let text = `Uploaded: ${attachment.filename} | ${attachment.mimeType} | ${formatSize(attachment.size)} | id:${attachment.id}`;
+      text += mediaNextSteps('upload', { issueKey: args.issueKey });
+      return { content: [{ type: 'text', text }] };
+    }
+
+    case 'delete': {
+      if (!args.attachmentId) {
+        return { content: [{ type: 'text', text: 'attachmentId is required for delete operation' }], isError: true };
+      }
+      await client.deleteAttachment(args.attachmentId);
+      return { content: [{ type: 'text', text: `Permanently deleted attachment ${args.attachmentId} from Jira. This cannot be undone.` }] };
+    }
+
+    case 'view': {
+      if (!args.attachmentId) {
+        return { content: [{ type: 'text', text: 'attachmentId is required for view operation' }], isError: true };
+      }
+      const info = await client.getAttachmentInfo(args.attachmentId);
+      if (!info.mimeType.startsWith('image/')) {
+        return {
+          content: [{
+            type: 'text',
+            text: `${info.filename} | ${info.mimeType} | ${formatSize(info.size)}\n\nNot an image — cannot display inline. Use download to fetch raw content.`,
+          }],
+        };
+      }
+      const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+      if (info.size > MAX_IMAGE_SIZE) {
+        return {
+          content: [{
+            type: 'text',
+            text: `${info.filename} | ${info.mimeType} | ${formatSize(info.size)}\n\nImage too large to display inline (${(info.size / 1024 / 1024).toFixed(1)}MB, max 5MB). Use download instead.`,
+          }],
+        };
+      }
+      const bytes = await client.downloadAttachment(args.attachmentId);
+      return {
+        content: [
+          { type: 'text', text: `${info.filename} | ${info.mimeType}` },
+          { type: 'image', data: bytes.toString('base64'), mimeType: info.mimeType },
+        ],
+      };
+    }
+
+    case 'get_info': {
+      if (!args.attachmentId) {
+        return { content: [{ type: 'text', text: 'attachmentId is required for get_info operation' }], isError: true };
+      }
+      const attachInfo = await client.getAttachmentInfo(args.attachmentId);
+      return {
+        content: [{
+          type: 'text',
+          text: `${attachInfo.filename} | ${attachInfo.mimeType} | ${formatSize(attachInfo.size)} | id:${attachInfo.id} | v${attachInfo.author} | ${attachInfo.created}`,
+        }],
+      };
+    }
+
+    case 'download': {
+      if (!args.attachmentId) {
+        return { content: [{ type: 'text', text: 'attachmentId is required for download operation' }], isError: true };
+      }
+      const dlInfo = await client.getAttachmentInfo(args.attachmentId);
+      const dlBytes = await client.downloadAttachment(args.attachmentId);
+
+      const status = await ensureWorkspaceDir();
+      if (!status.valid) {
+        return { content: [{ type: 'text', text: `Workspace invalid: ${status.warning}` }], isError: true };
+      }
+
+      const dlFilename = args.filename || sanitizeFilename(dlInfo.filename);
+      const dlPath = resolveWorkspacePath(dlFilename);
+      await verifyPathSafety(dlPath);
+      await ensureParentDir(dlPath);
+      await fs.writeFile(dlPath, dlBytes);
+
+      let text = `Downloaded: ${dlFilename} | ${dlInfo.mimeType} | ${formatSize(dlBytes.length)}\nPath: ${dlPath}`;
+      text += `\n\nUse manage_workspace read or manage_jira_media upload with workspaceFile:"${dlFilename}" to use it.`;
+      text += mediaNextSteps('download', {});
+      return { content: [{ type: 'text', text }] };
+    }
+
+    default:
+      return { content: [{ type: 'text', text: `Unknown media operation: ${args.operation}` }], isError: true };
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/src/handlers/media-handler.ts
+++ b/src/handlers/media-handler.ts
@@ -9,6 +9,7 @@ import type { JiraClient } from '../client/jira-client.js';
 import { mediaNextSteps } from '../utils/next-steps.js';
 import {
   ensureWorkspaceDir,
+  formatSize,
   resolveWorkspacePath,
   ensureParentDir,
   verifyPathSafety,
@@ -74,7 +75,8 @@ export async function handleMediaRequest(
         };
       }
 
-      const attachment = await client.uploadAttachment(args.issueKey, args.filename, buffer, args.mediaType);
+      const safeFilename = sanitizeFilename(args.filename);
+      const attachment = await client.uploadAttachment(args.issueKey, safeFilename, buffer, args.mediaType);
       let text = `Uploaded: ${attachment.filename} | ${attachment.mimeType} | ${formatSize(attachment.size)} | id:${attachment.id}`;
       text += mediaNextSteps('upload', { issueKey: args.issueKey });
       return { content: [{ type: 'text', text }] };
@@ -127,7 +129,7 @@ export async function handleMediaRequest(
       return {
         content: [{
           type: 'text',
-          text: `${attachInfo.filename} | ${attachInfo.mimeType} | ${formatSize(attachInfo.size)} | id:${attachInfo.id} | v${attachInfo.author} | ${attachInfo.created}`,
+          text: `${attachInfo.filename} | ${attachInfo.mimeType} | ${formatSize(attachInfo.size)} | id:${attachInfo.id} | ${attachInfo.author} | ${attachInfo.created}`,
         }],
       };
     }
@@ -161,8 +163,3 @@ export async function handleMediaRequest(
   }
 }
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}

--- a/src/handlers/workspace-handler.test.ts
+++ b/src/handlers/workspace-handler.test.ts
@@ -6,6 +6,11 @@ import { handleWorkspaceRequest } from './workspace-handler.js';
 // Mock workspace module
 vi.mock('../workspace/index.js', () => ({
   ensureWorkspaceDir: vi.fn().mockResolvedValue({ path: '/mock/workspace', valid: true }),
+  formatSize: (bytes: number) => {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  },
   resolveWorkspacePath: vi.fn((f: string) => `/mock/workspace/${f}`),
   ensureParentDir: vi.fn().mockResolvedValue(undefined),
   verifyPathSafety: vi.fn().mockResolvedValue(undefined),
@@ -64,6 +69,13 @@ describe('workspace-handler', () => {
       expect(result.content).toHaveLength(2);
       expect(result.content[1].type).toBe('image');
       expect(result.content[1].mimeType).toBe('image/png');
+    });
+
+    it('returns path reference for large text files', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ size: 200 * 1024 } as any); // 200KB
+      const result = await handleWorkspaceRequest({ operation: 'read', filename: 'huge.txt' });
+      expect(result.content[0].text).toContain('text');
+      expect(result.content[0].text).toContain('manage_jira_media upload');
     });
 
     it('returns path reference for binary files', async () => {

--- a/src/handlers/workspace-handler.test.ts
+++ b/src/handlers/workspace-handler.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as workspace from '../workspace/index.js';
+import { handleWorkspaceRequest } from './workspace-handler.js';
+
+// Mock workspace module
+vi.mock('../workspace/index.js', () => ({
+  ensureWorkspaceDir: vi.fn().mockResolvedValue({ path: '/mock/workspace', valid: true }),
+  resolveWorkspacePath: vi.fn((f: string) => `/mock/workspace/${f}`),
+  ensureParentDir: vi.fn().mockResolvedValue(undefined),
+  verifyPathSafety: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:fs/promises');
+
+describe('workspace-handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(workspace.ensureWorkspaceDir).mockResolvedValue({ path: '/mock/workspace', valid: true });
+  });
+
+  describe('list', () => {
+    it('shows empty workspace', async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      const result = await handleWorkspaceRequest({ operation: 'list' });
+      expect(result.content[0].text).toContain('empty');
+      expect(result.content[0].text).toContain('/mock/workspace');
+    });
+
+    it('fails when workspace is invalid', async () => {
+      vi.mocked(workspace.ensureWorkspaceDir).mockResolvedValueOnce({ path: '/bad', valid: false, warning: 'forbidden path' });
+      const result = await handleWorkspaceRequest({ operation: 'list' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Workspace invalid');
+    });
+  });
+
+  describe('read', () => {
+    it('requires filename', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'read' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('filename is required');
+    });
+
+    it('returns error for missing file', async () => {
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+      const result = await handleWorkspaceRequest({ operation: 'read', filename: 'missing.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('File not found');
+    });
+
+    it('inlines small text files', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ size: 100 });
+      vi.mocked(fs.readFile).mockResolvedValue('hello world');
+      const result = await handleWorkspaceRequest({ operation: 'read', filename: 'notes.txt' });
+      expect(result.content[0].text).toContain('hello world');
+      expect(result.content[0].text).toContain('notes.txt');
+    });
+
+    it('inlines small images', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ size: 1024 });
+      vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('fake png'));
+      const result = await handleWorkspaceRequest({ operation: 'read', filename: 'photo.png' });
+      expect(result.content).toHaveLength(2);
+      expect(result.content[1].type).toBe('image');
+      expect(result.content[1].mimeType).toBe('image/png');
+    });
+
+    it('returns path reference for binary files', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ size: 2048 });
+      const result = await handleWorkspaceRequest({ operation: 'read', filename: 'archive.zip' });
+      expect(result.content[0].text).toContain('binary');
+      expect(result.content[0].text).toContain('manage_jira_media upload');
+    });
+  });
+
+  describe('write', () => {
+    it('requires filename', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'write', content: 'abc' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('filename is required');
+    });
+
+    it('requires content', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'write', filename: 'test.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('content (base64-encoded) is required');
+    });
+
+    it('writes base64 content to workspace', async () => {
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      const b64 = Buffer.from('hello').toString('base64');
+      const result = await handleWorkspaceRequest({ operation: 'write', filename: 'test.txt', content: b64 });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Written: test.txt');
+      expect(vi.mocked(fs.writeFile)).toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it('requires filename', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'delete' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('deletes files and confirms local-only', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false });
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+      const result = await handleWorkspaceRequest({ operation: 'delete', filename: 'test.txt' });
+      expect(result.content[0].text).toContain('Deleted local file');
+      expect(result.content[0].text).toContain('Jira attachments unaffected');
+    });
+
+    it('recursively deletes directories and confirms local-only', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => true });
+      vi.mocked(fs.rm).mockResolvedValue(undefined);
+      const result = await handleWorkspaceRequest({ operation: 'delete', filename: 'subdir' });
+      expect(result.content[0].text).toContain('Deleted local directory');
+      expect(result.content[0].text).toContain('Jira attachments unaffected');
+    });
+
+    it('returns error for missing file', async () => {
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+      const result = await handleWorkspaceRequest({ operation: 'delete', filename: 'ghost.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('File not found');
+    });
+  });
+
+  describe('mkdir', () => {
+    it('requires filename', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'mkdir' });
+      expect(result.isError).toBe(true);
+    });
+
+    it('creates directory', async () => {
+      vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+      const result = await handleWorkspaceRequest({ operation: 'mkdir', filename: 'subdir' });
+      expect(result.content[0].text).toContain('Created: subdir/');
+    });
+  });
+
+  describe('move', () => {
+    it('requires filename', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'move', destination: 'b.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('filename');
+    });
+
+    it('requires destination', async () => {
+      const result = await handleWorkspaceRequest({ operation: 'move', filename: 'a.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('destination');
+    });
+
+    it('moves files', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ size: 100 });
+      vi.mocked(fs.rename).mockResolvedValue(undefined);
+      const result = await handleWorkspaceRequest({ operation: 'move', filename: 'a.txt', destination: 'b.txt' });
+      expect(result.content[0].text).toContain('Moved: a.txt');
+      expect(result.content[0].text).toContain('b.txt');
+    });
+
+    it('returns error for missing source', async () => {
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT'));
+      const result = await handleWorkspaceRequest({ operation: 'move', filename: 'ghost.txt', destination: 'b.txt' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Source not found');
+    });
+  });
+
+  it('rejects unknown operations', async () => {
+    const result = await handleWorkspaceRequest({ operation: 'explode' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Unknown workspace operation');
+  });
+});

--- a/src/handlers/workspace-handler.ts
+++ b/src/handlers/workspace-handler.ts
@@ -1,0 +1,266 @@
+/**
+ * Handler for manage_workspace tool.
+ * See ADR-211: Attachment and Workspace Management.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import {
+  ensureWorkspaceDir,
+  resolveWorkspacePath,
+  ensureParentDir,
+  verifyPathSafety,
+} from '../workspace/index.js';
+
+interface WorkspaceArgs {
+  operation: string;
+  filename?: string;
+  destination?: string;
+  content?: string;
+}
+
+const TEXT_INLINE_LIMIT = 100 * 1024; // 100KB
+const IMAGE_INLINE_LIMIT = 5 * 1024 * 1024; // 5MB
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+};
+
+const TEXT_EXTENSIONS = new Set([
+  '.txt', '.md', '.json', '.xml', '.csv', '.html', '.htm',
+  '.yaml', '.yml', '.toml', '.ini', '.cfg', '.conf', '.log',
+  '.js', '.ts', '.py', '.rb', '.sh', '.bash', '.zsh',
+  '.css', '.scss', '.less', '.svg',
+]);
+
+export async function handleWorkspaceRequest(
+  args: WorkspaceArgs,
+): Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }> {
+  switch (args.operation) {
+    case 'list':
+      return handleList();
+    case 'read':
+      return handleRead(args);
+    case 'write':
+      return handleWrite(args);
+    case 'delete':
+      return handleDelete(args);
+    case 'mkdir':
+      return handleMkdir(args);
+    case 'move':
+      return handleMove(args);
+    default:
+      return { content: [{ type: 'text', text: `Unknown workspace operation: ${args.operation}` }], isError: true };
+  }
+}
+
+async function handleList(): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  const status = await ensureWorkspaceDir();
+  if (!status.valid) {
+    return { content: [{ type: 'text', text: `Workspace invalid: ${status.warning}` }], isError: true };
+  }
+
+  const lines: string[] = [`Workspace: ${status.path}\n`];
+  await listRecursive(status.path, status.path, lines, 0);
+
+  if (lines.length === 1) {
+    return { content: [{ type: 'text', text: `Workspace: ${status.path}\n\n(empty — no files staged)` }] };
+  }
+
+  return { content: [{ type: 'text', text: lines.join('\n') }] };
+}
+
+const MAX_LIST_DEPTH = 10;
+
+async function listRecursive(rootDir: string, dir: string, lines: string[], depth: number): Promise<void> {
+  if (depth >= MAX_LIST_DEPTH) {
+    lines.push(`${'  '.repeat(depth + 1)}(truncated — max depth ${MAX_LIST_DEPTH})`);
+    return;
+  }
+
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const indent = '  '.repeat(depth + 1);
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) continue; // skip symlinks to prevent loops
+    try {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        lines.push(`${indent}${entry.name}/`);
+        await listRecursive(rootDir, fullPath, lines, depth + 1);
+      } else if (entry.isFile()) {
+        const stat = await fs.stat(fullPath);
+        lines.push(`${indent}${entry.name}  (${formatSize(stat.size)}, ${stat.mtime.toISOString().slice(0, 16)})`);
+      }
+    } catch {
+      // Skip entries we can't stat
+    }
+  }
+}
+
+async function handleRead(args: WorkspaceArgs): Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean }> {
+  if (!args.filename) {
+    return { content: [{ type: 'text', text: 'filename is required for read operation' }], isError: true };
+  }
+
+  const filePath = resolveWorkspacePath(args.filename);
+  await verifyPathSafety(filePath);
+
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(filePath);
+  } catch {
+    return { content: [{ type: 'text', text: `File not found in workspace: ${args.filename}` }], isError: true };
+  }
+
+  const ext = path.extname(args.filename).toLowerCase();
+  const isText = TEXT_EXTENSIONS.has(ext);
+  const imageMime = IMAGE_EXTENSIONS[ext];
+
+  // Inline text
+  if (isText && stat.size <= TEXT_INLINE_LIMIT) {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return { content: [{ type: 'text', text: `File: ${args.filename} (${formatSize(stat.size)})\nPath: ${filePath}\n\n${content}` }] };
+  }
+
+  // Inline image
+  if (imageMime && stat.size <= IMAGE_INLINE_LIMIT) {
+    const bytes = await fs.readFile(filePath);
+    return {
+      content: [
+        { type: 'text', text: `File: ${args.filename} | ${formatSize(stat.size)}\nPath: ${filePath}` },
+        { type: 'image', data: bytes.toString('base64'), mimeType: imageMime },
+      ],
+    };
+  }
+
+  // Too large or unsupported — path reference only
+  const label = imageMime ? 'image (too large to display inline)' : isText ? 'text' : 'binary';
+  return {
+    content: [{
+      type: 'text',
+      text: `File: ${args.filename} | ${formatSize(stat.size)} | ${label}\nPath: ${filePath}\n\nUse manage_jira_media upload with workspaceFile to upload, or manage_workspace delete to remove.`,
+    }],
+  };
+}
+
+async function handleWrite(args: WorkspaceArgs): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  if (!args.filename) {
+    return { content: [{ type: 'text', text: 'filename is required for write operation' }], isError: true };
+  }
+  if (!args.content) {
+    return { content: [{ type: 'text', text: 'content (base64-encoded) is required for write operation' }], isError: true };
+  }
+
+  const status = await ensureWorkspaceDir();
+  if (!status.valid) {
+    return { content: [{ type: 'text', text: `Workspace invalid: ${status.warning}` }], isError: true };
+  }
+
+  const filePath = resolveWorkspacePath(args.filename);
+  await verifyPathSafety(filePath);
+  await ensureParentDir(filePath);
+
+  const buffer = Buffer.from(args.content, 'base64');
+  await fs.writeFile(filePath, buffer);
+
+  return {
+    content: [{
+      type: 'text',
+      text: `Written: ${args.filename} (${formatSize(buffer.length)})\nPath: ${filePath}`,
+    }],
+  };
+}
+
+async function handleDelete(args: WorkspaceArgs): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  if (!args.filename) {
+    return { content: [{ type: 'text', text: 'filename is required for delete operation' }], isError: true };
+  }
+
+  const filePath = resolveWorkspacePath(args.filename);
+  await verifyPathSafety(filePath);
+
+  try {
+    const stat = await fs.stat(filePath);
+    if (stat.isDirectory()) {
+      await fs.rm(filePath, { recursive: true });
+      return { content: [{ type: 'text', text: `Deleted local directory: ${args.filename} (Jira attachments unaffected)` }] };
+    }
+    await fs.unlink(filePath);
+  } catch {
+    return { content: [{ type: 'text', text: `File not found in workspace: ${args.filename}` }], isError: true };
+  }
+
+  return { content: [{ type: 'text', text: `Deleted local file: ${args.filename} (Jira attachments unaffected)` }] };
+}
+
+async function handleMkdir(args: WorkspaceArgs): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  if (!args.filename) {
+    return { content: [{ type: 'text', text: 'filename (directory path) is required for mkdir operation' }], isError: true };
+  }
+
+  const status = await ensureWorkspaceDir();
+  if (!status.valid) {
+    return { content: [{ type: 'text', text: `Workspace invalid: ${status.warning}` }], isError: true };
+  }
+
+  const dirPath = resolveWorkspacePath(args.filename);
+  await verifyPathSafety(dirPath);
+  await fs.mkdir(dirPath, { recursive: true, mode: 0o755 });
+
+  return {
+    content: [{
+      type: 'text',
+      text: `Created: ${args.filename}/\nPath: ${dirPath}`,
+    }],
+  };
+}
+
+async function handleMove(args: WorkspaceArgs): Promise<{ content: Array<{ type: string; text?: string }>; isError?: boolean }> {
+  if (!args.filename) {
+    return { content: [{ type: 'text', text: 'filename (source path) is required for move operation' }], isError: true };
+  }
+  if (!args.destination) {
+    return { content: [{ type: 'text', text: 'destination path is required for move operation' }], isError: true };
+  }
+
+  const srcPath = resolveWorkspacePath(args.filename);
+  await verifyPathSafety(srcPath);
+  const destPath = resolveWorkspacePath(args.destination);
+  await verifyPathSafety(destPath);
+
+  try {
+    await fs.stat(srcPath);
+  } catch {
+    return { content: [{ type: 'text', text: `Source not found in workspace: ${args.filename}` }], isError: true };
+  }
+
+  await ensureParentDir(destPath);
+  await fs.rename(srcPath, destPath);
+
+  return {
+    content: [{
+      type: 'text',
+      text: `Moved: ${args.filename} -> ${args.destination}\nPath: ${destPath}`,
+    }],
+  };
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/src/handlers/workspace-handler.ts
+++ b/src/handlers/workspace-handler.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 
 import {
   ensureWorkspaceDir,
+  formatSize,
   resolveWorkspacePath,
   ensureParentDir,
   verifyPathSafety,
@@ -257,10 +258,4 @@ async function handleMove(args: WorkspaceArgs): Promise<{ content: Array<{ type:
       text: `Moved: ${args.filename} -> ${args.destination}\nPath: ${destPath}`,
     }],
   };
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,15 +23,18 @@ import { handleAnalysisRequest } from './handlers/analysis-handler.js';
 import { handleBoardRequest } from './handlers/board-handlers.js';
 import { handleFilterRequest } from './handlers/filter-handlers.js';
 import { handleIssueRequest } from './handlers/issue-handlers.js';
+import { handleMediaRequest } from './handlers/media-handler.js';
 import { handlePlanRequest } from './handlers/plan-handler.js';
 import { handleProjectRequest } from './handlers/project-handlers.js';
 import { createQueueHandler } from './handlers/queue-handler.js';
 import { setupResourceHandlers } from './handlers/resource-handlers.js';
 import { handleSprintRequest } from './handlers/sprint-handlers.js';
+import { handleWorkspaceRequest } from './handlers/workspace-handler.js';
 import { promptDefinitions } from './prompts/prompt-definitions.js';
 import { getPrompt } from './prompts/prompt-messages.js';
 import { toolSchemas } from './schemas/tool-schemas.js';
 import type { GraphIssue } from './types/index.js';
+import { normalizeArgs } from './utils/normalize-args.js';
 
 // Jira credentials from environment variables
 const JIRA_EMAIL = process.env.JIRA_EMAIL;
@@ -187,6 +190,8 @@ class JiraServer {
           manage_jira_sprint: handleSprintRequest,
           manage_jira_filter: handleFilterRequest,
           analyze_jira_issues: (client, req) => handleAnalysisRequest(client, req, this.graphqlClient, this.cache),
+          manage_jira_media: (client, req) => handleMediaRequest(client, normalizeArgs(req.params.arguments ?? {}) as any),
+          manage_workspace: (_client, req) => handleWorkspaceRequest(normalizeArgs(req.params.arguments ?? {}) as any),
         };
 
         const handlers: Record<string, (client: JiraClient, req: typeof request) => Promise<any>> = {

--- a/src/schemas/tool-schemas.test.ts
+++ b/src/schemas/tool-schemas.test.ts
@@ -9,10 +9,10 @@ const DOMAIN_TOOLS = [
   'manage_jira_sprint',
 ];
 
-const ALL_TOOLS = [...DOMAIN_TOOLS, 'analyze_jira_issues', 'manage_jira_plan', 'queue_jira_operations'];
+const ALL_TOOLS = [...DOMAIN_TOOLS, 'analyze_jira_issues', 'manage_jira_media', 'manage_jira_plan', 'manage_workspace', 'queue_jira_operations'];
 
 describe('toolSchemas', () => {
-  it('exports all 8 tools', () => {
+  it('exports all 10 tools', () => {
     expect(Object.keys(toolSchemas).sort()).toEqual(ALL_TOOLS.sort());
   });
 

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -498,6 +498,74 @@ export const toolSchemas = {
     },
   },
 
+  manage_jira_media: {
+    name: 'manage_jira_media',
+    description: 'Manage file attachments on Jira issues (remote). Operations here affect Jira — delete permanently removes an attachment from the issue for all users. Use manage_workspace for local file staging. Downloads copy from Jira to workspace; uploads copy from workspace to Jira.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: ['list', 'upload', 'download', 'view', 'get_info', 'delete'],
+          description: 'Operation to perform. list: attachments on an issue. upload: copy file from workspace to Jira issue. download: copy attachment from Jira to local workspace. view: display image inline. get_info: attachment metadata. delete: permanently remove attachment from Jira (affects all users).',
+        },
+        issueKey: {
+          type: 'string',
+          description: 'Issue key (e.g., PROJ-123). Required for list and upload.',
+        },
+        attachmentId: {
+          type: 'string',
+          description: 'Attachment ID. Required for download, view, get_info, delete.',
+        },
+        filename: {
+          type: 'string',
+          description: 'Filename for upload (required) or download (optional override).',
+        },
+        content: {
+          type: 'string',
+          description: 'Base64-encoded file content for upload. Alternative to workspaceFile.',
+        },
+        mediaType: {
+          type: 'string',
+          description: 'MIME type (e.g., "image/png", "application/pdf"). Required for upload.',
+        },
+        workspaceFile: {
+          type: 'string',
+          description: 'Filename in workspace to upload. Alternative to content. Use manage_workspace list to see staged files.',
+        },
+      },
+      required: ['operation'],
+    },
+  },
+
+  manage_workspace: {
+    name: 'manage_workspace',
+    description: 'Manage files in the local workspace staging area (local only — no Jira impact). Files downloaded via manage_jira_media land here. Delete only removes the local copy. Use manage_jira_media to affect attachments on Jira issues.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: {
+          type: 'string',
+          enum: ['list', 'read', 'write', 'delete', 'mkdir', 'move'],
+          description: 'Operation to perform. list: show staged files. read: display file content. write: stage base64 content. delete: remove local file only (does not affect Jira). mkdir: create directory. move: rename/relocate file.',
+        },
+        filename: {
+          type: 'string',
+          description: 'Filename or path within workspace. Supports nesting with / separators.',
+        },
+        destination: {
+          type: 'string',
+          description: 'Destination path for move operation.',
+        },
+        content: {
+          type: 'string',
+          description: 'Base64-encoded content for write operation.',
+        },
+      },
+      required: ['operation'],
+    },
+  },
+
   queue_jira_operations: {
     name: 'queue_jira_operations',
     description: 'Execute multiple Jira operations in a single call. Operations run sequentially with result references ($0.key) and per-operation error strategies (bail/continue). Powerful for analysis pipelines: create a filter, then run multiple analyze_jira_issues calls against $0.filterId with different groupBy/compute — all in one call.',
@@ -511,7 +579,7 @@ export const toolSchemas = {
             properties: {
               tool: {
                 type: 'string',
-                enum: ['manage_jira_issue', 'manage_jira_filter', 'manage_jira_sprint', 'manage_jira_project', 'manage_jira_board', 'analyze_jira_issues'],
+                enum: ['manage_jira_issue', 'manage_jira_filter', 'manage_jira_sprint', 'manage_jira_project', 'manage_jira_board', 'analyze_jira_issues', 'manage_jira_media', 'manage_workspace'],
                 description: 'Which tool to call.',
               },
               args: {

--- a/src/utils/next-steps.ts
+++ b/src/utils/next-steps.ts
@@ -31,6 +31,7 @@ export function issueNextSteps(operation: string, issueKey?: string): string {
         { description: 'Update fields', tool: 'manage_jira_issue', example: { operation: 'update', issueKey } },
         { description: 'Add a comment', tool: 'manage_jira_issue', example: { operation: 'comment', issueKey, comment: '<text>' } },
         { description: 'View available transitions', tool: 'manage_jira_issue', example: { operation: 'get', issueKey, expand: ['transitions'] } },
+        { description: 'Manage attachments (upload, download, view)', tool: 'manage_jira_media', example: { operation: 'list', issueKey } },
       );
       break;
     case 'update':
@@ -314,6 +315,33 @@ export function goalNextSteps(operation: string, goalKey?: string, workItemCount
           { description: 'Analyze goal progress', tool: 'manage_jira_plan', example: { operation: 'analyze', goalKey } },
         );
       }
+      break;
+  }
+  return steps.length > 0 ? formatSteps(steps) : '';
+}
+
+export function mediaNextSteps(operation: string, context: { issueKey?: string }): string {
+  const steps: NextStep[] = [];
+  switch (operation) {
+    case 'list':
+      steps.push(
+        { description: 'Download an attachment to workspace', tool: 'manage_jira_media', example: { operation: 'download', attachmentId: '<id>' } },
+        { description: 'View an image attachment inline', tool: 'manage_jira_media', example: { operation: 'view', attachmentId: '<id>' } },
+        { description: 'Upload a file to this issue', tool: 'manage_jira_media', example: { operation: 'upload', issueKey: context.issueKey, filename: '<name>', mediaType: '<mime>', workspaceFile: '<staged file>' } },
+      );
+      break;
+    case 'upload':
+      steps.push(
+        { description: 'List attachments on this issue', tool: 'manage_jira_media', example: { operation: 'list', issueKey: context.issueKey } },
+        { description: 'View the issue', tool: 'manage_jira_issue', example: { operation: 'get', issueKey: context.issueKey } },
+      );
+      break;
+    case 'download':
+      steps.push(
+        { description: 'View staged files in workspace', tool: 'manage_workspace', example: { operation: 'list' } },
+        { description: 'Upload to another issue', tool: 'manage_jira_media', example: { operation: 'upload', issueKey: '<target issue>', workspaceFile: '<filename>', mediaType: '<mime>', filename: '<filename>' } },
+        { description: 'Read the downloaded file', tool: 'manage_workspace', example: { operation: 'read', filename: '<filename>' } },
+      );
       break;
   }
   return steps.length > 0 ? formatSteps(steps) : '';

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -1,0 +1,14 @@
+export {
+  checkWorkspaceStatus,
+  dataDir,
+  ensureParentDir,
+  ensureWorkspaceDir,
+  getWorkspaceDir,
+  resolveWorkspacePath,
+  sanitizeFilename,
+  sanitizePath,
+  validateWorkspaceDir,
+  verifyPathSafety,
+} from './workspace.js';
+
+export type { WorkspaceStatus } from './workspace.js';

--- a/src/workspace/index.ts
+++ b/src/workspace/index.ts
@@ -3,6 +3,7 @@ export {
   dataDir,
   ensureParentDir,
   ensureWorkspaceDir,
+  formatSize,
   getWorkspaceDir,
   resolveWorkspacePath,
   sanitizeFilename,

--- a/src/workspace/workspace.test.ts
+++ b/src/workspace/workspace.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  sanitizeFilename,
+  sanitizePath,
+  resolveWorkspacePath,
+  getWorkspaceDir,
+  validateWorkspaceDir,
+  checkWorkspaceStatus,
+} from './workspace.js';
+
+describe('sanitizeFilename', () => {
+  it('passes through normal filenames', () => {
+    expect(sanitizeFilename('report.pdf')).toBe('report.pdf');
+    expect(sanitizeFilename('my-file_v2.txt')).toBe('my-file_v2.txt');
+  });
+
+  it('removes path separators', () => {
+    expect(sanitizeFilename('foo/bar')).toBe('foo_bar');
+    expect(sanitizeFilename('foo\\bar')).toBe('foo_bar');
+  });
+
+  it('removes null bytes and control characters', () => {
+    expect(sanitizeFilename('file\x00name.txt')).toBe('filename.txt');
+    expect(sanitizeFilename('file\x1fname.txt')).toBe('filename.txt');
+  });
+
+  it('removes dangerous characters', () => {
+    expect(sanitizeFilename('file<>:"|?*.txt')).toBe('file_.txt');
+  });
+
+  it('collapses multiple underscores', () => {
+    expect(sanitizeFilename('a___b')).toBe('a_b');
+  });
+
+  it('removes leading dots', () => {
+    expect(sanitizeFilename('.hidden')).toBe('hidden');
+    expect(sanitizeFilename('...triple')).toBe('triple');
+  });
+
+  it('removes trailing dots and spaces', () => {
+    expect(sanitizeFilename('file.  ')).toBe('file');
+    expect(sanitizeFilename('file...')).toBe('file');
+  });
+
+  it('returns "unnamed" for empty result', () => {
+    expect(sanitizeFilename('')).toBe('unnamed');
+    expect(sanitizeFilename('...')).toBe('unnamed');
+    expect(sanitizeFilename('<>:"|?*')).toBe('_');
+  });
+});
+
+describe('sanitizePath', () => {
+  it('preserves directory structure', () => {
+    expect(sanitizePath('projects/report.csv')).toMatch(/projects.report\.csv/);
+  });
+
+  it('strips traversal attempts', () => {
+    const result = sanitizePath('../../../etc/passwd');
+    expect(result).not.toContain('..');
+    expect(result).toContain('etc');
+    expect(result).toContain('passwd');
+  });
+
+  it('returns "unnamed" for empty input', () => {
+    expect(sanitizePath('')).toBe('unnamed');
+  });
+
+  it('sanitizes each segment individually', () => {
+    const result = sanitizePath('dir<name>/file?.txt');
+    expect(result).not.toContain('<');
+    expect(result).not.toContain('?');
+  });
+});
+
+describe('resolveWorkspacePath', () => {
+  it('resolves within workspace directory', () => {
+    const result = resolveWorkspacePath('test.txt');
+    expect(result).toContain(getWorkspaceDir());
+    expect(result).toContain('test.txt');
+  });
+
+  it('handles nested paths', () => {
+    const result = resolveWorkspacePath('sub/dir/file.txt');
+    expect(result).toContain(getWorkspaceDir());
+    expect(result).toContain('file.txt');
+  });
+
+  it('blocks traversal attempts', () => {
+    // The sanitizer strips ".." segments, so traversal resolves inside workspace
+    const result = resolveWorkspacePath('../../../etc/passwd');
+    expect(result).toContain(getWorkspaceDir());
+    expect(result).not.toContain('..');
+  });
+});
+
+describe('validateWorkspaceDir', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('accepts a normal workspace path', () => {
+    expect(() => validateWorkspaceDir('/tmp/test-workspace')).not.toThrow();
+  });
+
+  it('rejects home directory', () => {
+    const home = process.env.HOME!;
+    expect(() => validateWorkspaceDir(home)).toThrow('cannot be');
+  });
+
+  it('rejects filesystem root', () => {
+    expect(() => validateWorkspaceDir('/')).toThrow('filesystem root');
+  });
+
+  it('rejects cloud sync paths', () => {
+    expect(() => validateWorkspaceDir('/home/user/Google Drive/workspace')).toThrow('cloud sync');
+    expect(() => validateWorkspaceDir('/home/user/Dropbox/workspace')).toThrow('cloud sync');
+    expect(() => validateWorkspaceDir('/home/user/OneDrive/workspace')).toThrow('cloud sync');
+  });
+
+  it('accepts subdirectories of protected paths', () => {
+    const home = process.env.HOME!;
+    expect(() => validateWorkspaceDir(`${home}/.local/share/test`)).not.toThrow();
+  });
+});
+
+describe('checkWorkspaceStatus', () => {
+  it('returns valid for default workspace', () => {
+    const status = checkWorkspaceStatus();
+    expect(status.valid).toBe(true);
+    expect(status.path).toContain('jira-cloud-mcp');
+  });
+
+  it('returns invalid with warning for bad workspace', () => {
+    const originalEnv = process.env.WORKSPACE_DIR;
+    process.env.WORKSPACE_DIR = process.env.HOME!;
+    try {
+      const status = checkWorkspaceStatus();
+      expect(status.valid).toBe(false);
+      expect(status.warning).toBeDefined();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.WORKSPACE_DIR;
+      } else {
+        process.env.WORKSPACE_DIR = originalEnv;
+      }
+    }
+  });
+});
+
+describe('getWorkspaceDir', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('respects WORKSPACE_DIR env override', () => {
+    process.env.WORKSPACE_DIR = '/custom/workspace';
+    expect(getWorkspaceDir()).toBe('/custom/workspace');
+  });
+
+  it('ignores WORKSPACE_DIR with unexpanded variables', () => {
+    process.env.WORKSPACE_DIR = '${HOME}/workspace';
+    expect(getWorkspaceDir()).not.toContain('${');
+  });
+
+  it('uses XDG_DATA_HOME when set', () => {
+    delete process.env.WORKSPACE_DIR;
+    process.env.XDG_DATA_HOME = '/custom/data';
+    expect(getWorkspaceDir()).toBe('/custom/data/jira-cloud-mcp/workspace');
+  });
+
+  it('defaults to ~/.local/share', () => {
+    delete process.env.WORKSPACE_DIR;
+    delete process.env.XDG_DATA_HOME;
+    expect(getWorkspaceDir()).toContain('.local/share/jira-cloud-mcp/workspace');
+  });
+});

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -1,0 +1,212 @@
+/**
+ * Workspace directory — safe sandbox for file staging operations.
+ *
+ * All file operations (attachment download, upload, media staging) are jailed
+ * to this directory. Prevents agents from accidentally operating on home
+ * directories, document folders, or cloud sync mount points.
+ *
+ * See ADR-211: Attachment and Workspace Management.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const APP_NAME = 'jira-cloud-mcp';
+
+// ── XDG Paths ──────────────────────────────────────────────
+
+export function dataDir(): string {
+  const base = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+  return path.join(base, APP_NAME);
+}
+
+// ── Forbidden Paths ────────────────────────────────────────
+
+/** Paths that must never be used as the workspace root. */
+const FORBIDDEN_PATHS = [
+  () => process.env.HOME ?? '',
+  () => process.env.USERPROFILE ?? '',
+  () => process.env.HOME ? path.join(process.env.HOME, 'Documents') : '',
+  () => process.env.HOME ? path.join(process.env.HOME, 'Desktop') : '',
+  () => process.env.HOME ? path.join(process.env.HOME, 'Downloads') : '',
+  () => process.env.USERPROFILE ? path.join(process.env.USERPROFILE, 'Documents') : '',
+  () => process.env.USERPROFILE ? path.join(process.env.USERPROFILE, 'Desktop') : '',
+  () => process.env.USERPROFILE ? path.join(process.env.USERPROFILE, 'Downloads') : '',
+];
+
+/** Path substrings that indicate a cloud sync mount. */
+const CLOUD_SYNC_PATTERNS = [
+  'google-drive',
+  'Google Drive',
+  'GoogleDrive',
+  'gdrive',
+  'My Drive',
+  'OneDrive',
+  'onedrive',
+  'Dropbox',
+  'dropbox',
+  'iCloud Drive',
+  'iCloudDrive',
+];
+
+// ── Workspace Directory ────────────────────────────────────
+
+/** Get the workspace directory path, respecting env overrides. */
+export function getWorkspaceDir(): string {
+  const configured = process.env.WORKSPACE_DIR;
+  if (configured && !configured.includes('${')) {
+    return configured;
+  }
+  return path.join(dataDir(), 'workspace');
+}
+
+/**
+ * Validate workspace dir is safe. Throws if it IS a protected directory.
+ * Being a subdirectory OF a protected directory is fine.
+ */
+export function validateWorkspaceDir(dir: string): void {
+  const resolved = path.resolve(dir);
+
+  for (const getForbidden of FORBIDDEN_PATHS) {
+    const forbidden = getForbidden();
+    if (forbidden && path.resolve(forbidden) === resolved) {
+      throw new Error(
+        `Workspace directory cannot be ${resolved} — use a subdirectory like ${getWorkspaceDir()}`,
+      );
+    }
+  }
+
+  for (const pattern of CLOUD_SYNC_PATTERNS) {
+    if (resolved.toLowerCase().includes(pattern.toLowerCase())) {
+      throw new Error(
+        `Workspace directory cannot be inside a cloud sync mount (${resolved}) — this could cause sync conflicts`,
+      );
+    }
+  }
+
+  if (resolved === '/' || resolved === 'C:\\') {
+    throw new Error('Workspace directory cannot be the filesystem root');
+  }
+}
+
+export interface WorkspaceStatus {
+  path: string;
+  valid: boolean;
+  warning?: string;
+}
+
+/** Check workspace directory status without throwing. */
+export function checkWorkspaceStatus(): WorkspaceStatus {
+  const dir = getWorkspaceDir();
+  try {
+    validateWorkspaceDir(dir);
+    return { path: dir, valid: true };
+  } catch (err) {
+    return { path: dir, valid: false, warning: (err as Error).message };
+  }
+}
+
+/** Ensure the workspace directory exists and is validated. */
+export async function ensureWorkspaceDir(): Promise<WorkspaceStatus> {
+  const status = checkWorkspaceStatus();
+  if (status.valid) {
+    await fs.mkdir(status.path, { recursive: true, mode: 0o755 });
+  }
+  return status;
+}
+
+// ── Filename Sanitization ──────────────────────────────────
+
+/**
+ * Sanitize a single filename segment (no separators).
+ * Strips null bytes, control characters, path separators, and dangerous chars.
+ */
+export function sanitizeFilename(filename: string): string {
+  return filename
+    // Remove null bytes and control characters
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    // Remove path separators
+    .replace(/[/\\]/g, '_')
+    // Remove other dangerous characters
+    .replace(/[<>:"|?*]/g, '_')
+    // Collapse multiple underscores
+    .replace(/_+/g, '_')
+    // Remove leading dots (hidden files) and trailing dots/spaces
+    .replace(/^\.+/, '')
+    .replace(/[. ]+$/, '')
+    || 'unnamed';
+}
+
+/**
+ * Sanitize a workspace path that may contain directory separators.
+ * Each path segment is sanitized individually, preserving the directory structure.
+ * Empty segments and traversal attempts (e.g. '..') are removed.
+ */
+export function sanitizePath(filePath: string): string {
+  // Normalize separators to forward slash, split into segments
+  const segments = filePath
+    .replace(/\\/g, '/')
+    .split('/')
+    .map(seg => sanitizeFilename(seg))
+    // Drop segments that sanitized to 'unnamed' (e.g. '..' → '' → 'unnamed').
+    // Only keep 'unnamed' if the entire input was empty (fallback sentinel).
+    .filter(seg => seg !== 'unnamed' || filePath.trim() === '');
+
+  if (segments.length === 0) return 'unnamed';
+  return segments.join(path.sep);
+}
+
+// ── Path Resolution ────────────────────────────────────────
+
+/**
+ * Resolve a file path within the workspace directory.
+ * Supports nested paths (e.g. 'projects/report.csv').
+ * Prevents path traversal and sanitizes each path segment.
+ */
+export function resolveWorkspacePath(filePath: string): string {
+  const dir = getWorkspaceDir();
+  // Use sanitizePath for nested paths, sanitizeFilename for flat filenames
+  const sanitized = filePath.includes('/') || filePath.includes('\\')
+    ? sanitizePath(filePath)
+    : sanitizeFilename(filePath);
+  const resolved = path.resolve(dir, sanitized);
+
+  const resolvedDir = path.resolve(dir);
+  if (!resolved.startsWith(resolvedDir + path.sep) && resolved !== resolvedDir) {
+    throw new Error(
+      `Path traversal detected: "${filePath}" resolves outside workspace directory`,
+    );
+  }
+
+  return resolved;
+}
+
+/**
+ * Ensure parent directories exist for a workspace path.
+ * Call after resolveWorkspacePath to create intermediate dirs.
+ */
+export async function ensureParentDir(filePath: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true, mode: 0o755 });
+}
+
+/**
+ * Verify a file path is safe after symlink resolution.
+ * Must be called before any fs operation on a workspace path.
+ */
+export async function verifyPathSafety(filePath: string): Promise<void> {
+  const dir = path.resolve(getWorkspaceDir());
+  try {
+    const real = await fs.realpath(filePath);
+    if (!real.startsWith(dir + path.sep) && real !== dir) {
+      throw new Error(
+        `Symlink escape detected: "${filePath}" resolves to "${real}" outside workspace`,
+      );
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+}

--- a/src/workspace/workspace.ts
+++ b/src/workspace/workspace.ts
@@ -192,6 +192,17 @@ export async function ensureParentDir(filePath: string): Promise<void> {
   await fs.mkdir(dir, { recursive: true, mode: 0o755 });
 }
 
+// ── Formatting ─────────────────────────────────────────────
+
+/** Format byte count as human-readable size. */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+// ── Path Safety ────────────────────────────────────────────
+
 /**
  * Verify a file path is safe after symlink resolution.
  * Must be called before any fs operation on a workspace path.


### PR DESCRIPTION
## Summary

- Adds `manage_jira_media` tool for Jira attachment CRUD (list, upload, download, view, get_info, delete)
- Adds `manage_workspace` tool for local file staging in an XDG-compliant sandboxed directory
- Ported from confluence-cloud ADR-502 pattern — consistent interface across the MCP server family
- Clear local/remote boundary: media operations affect Jira (permanent), workspace operations are local-only
- 67 new tests across workspace sanitization, media handler, and workspace handler

## Design

Two-tool model separating concerns:
- **Remote (Jira):** `manage_jira_media` — attachments on issues, upload/download bridge
- **Local (staging):** `manage_workspace` — sandboxed file ops at `~/.local/share/jira-cloud-mcp/workspace/`

Security sandbox prevents path traversal, symlink escape, and use of protected directories (home, Documents, cloud sync mounts).

Tool count: 8 → 10. Both added to `queue_jira_operations` enum. Next-steps steering wired bidirectionally.

## Test plan

- [x] `make check` passes (405 tests, 0 errors)
- [x] Live tested: list attachments, download to workspace, upload from workspace, view inline image, workspace CRUD
- [x] Tested on PAID-192 with 2.5MB PNG upload/download/view cycle
- [x] Verified local/remote delete messaging distinction