### PR TITLE
ADR-214 v1: progressive reveal of custom fields in manage_jira_issue

### DIFF
--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -33,4 +33,4 @@ _MCP tool API surface, LLM interaction patterns, schema design_
 | [ADR-210](./tools/ADR-210-townsquare-goals-and-projects-integration.md) | Townsquare Goals and Projects Integration | Draft |
 | [ADR-211](./tools/ADR-211-attachment-and-workspace-management.md) | Attachment and Workspace Management | Draft |
 | [ADR-213](./tools/ADR-213-custom-field-robustness-and-capability-aware-field-routing.md) | Custom field robustness and capability-aware field routing | Accepted |
-| [ADR-214](./tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md) | Progressive reveal of custom fields in `manage_jira_issue` | Draft |
+| [ADR-214](./tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md) | Progressive reveal of custom fields in `manage_jira_issue` | Accepted |

--- a/docs/architecture/INDEX.md
+++ b/docs/architecture/INDEX.md
@@ -33,3 +33,4 @@ _MCP tool API surface, LLM interaction patterns, schema design_
 | [ADR-210](./tools/ADR-210-townsquare-goals-and-projects-integration.md) | Townsquare Goals and Projects Integration | Draft |
 | [ADR-211](./tools/ADR-211-attachment-and-workspace-management.md) | Attachment and Workspace Management | Draft |
 | [ADR-213](./tools/ADR-213-custom-field-robustness-and-capability-aware-field-routing.md) | Custom field robustness and capability-aware field routing | Accepted |
+| [ADR-214](./tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md) | Progressive reveal of custom fields in `manage_jira_issue` | Draft |

--- a/docs/architecture/tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md
+++ b/docs/architecture/tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md
@@ -1,0 +1,83 @@
+---
+status: Draft
+date: 2026-05-11
+deciders:
+  - aaronsb
+related:
+  - ADR-200
+  - ADR-201
+  - ADR-213
+---
+
+# ADR-214: Progressive reveal of custom fields in `manage_jira_issue`
+
+## Context
+
+ADR-213 §A2 made populated custom field values render by default on `manage_jira_issue get` once the field catalog was ready. Live testing of the post-ADR-213 build (against a tenant with 498 custom fields, 35–40 populated per issue) revealed two problems:
+
+1. **The cost is significant.** A routine `get` rendered a 35-line `Custom Fields:` block — roughly 600 tokens of content the caller didn't ask for. Multiply across a session of issue navigation and it dominates the conversation.
+2. **It's inconsistent with every other rich section on the same tool.** `comments`, `transitions`, `attachments`, `history` are all explicit `expand` options — opt-in by design. Custom field values were the lone always-on rich section.
+
+The same issue affects the post-write re-fetch rendered by `handleCreateIssue` / `handleUpdateIssue` / `handleMoveIssue` / `handleTransitionIssue`, which already carries a tailored `Applied:` section (ADR-213 §A4) listing what the caller just touched — so the additional Custom Fields dump is pure noise after a write.
+
+## Decision
+
+**Default `get` returns no Custom Fields block.** When the issue has any populated custom fields, the rendered output ends with a one-line **breadcrumb** instead:
+
+> *📋 35 populated custom fields not shown. To view: `expand: ["custom_fields"]`. For what's settable on this issue type: read `jira://custom-fields/PAID/Task`.*
+
+If the issue has zero populated custom fields (or the catalog is `unavailable`), the breadcrumb is omitted entirely.
+
+`expand: ["custom_fields"]` (already in the enum from ADR-213 §A2) becomes the opt-in: when present, render the populated set as before. This restores the rest of `expand`'s opt-in pattern.
+
+**Post-write renders drop the Custom Fields dump unconditionally.** `Applied:` already shows the fields the caller just modified with their post-write values; the broader dump is redundant. The breadcrumb is also omitted there — the caller's attention belongs on what they wrote, not on the rest of the issue's state.
+
+**Discovery surface for "what could I set?" stays where it is:** `jira://custom-fields/{projectKey}/{issueType}` lists every settable field on the issue type's create screen, with descriptions and allowed values. The breadcrumb points at it.
+
+### Implementation sketch
+
+- `MarkdownRenderer.renderIssue(issue, transitions, opts?)` gains an `opts.customFields: 'breadcrumb' | 'dump'` parameter (default `'breadcrumb'`). In breadcrumb mode it emits the one-liner from a count of `issue.customFieldValues`; in dump mode the existing block. Zero-population: no breadcrumb in either mode.
+- `handleGetIssue` passes `'dump'` when `expansionOptions.custom_fields` is true; `'breadcrumb'` otherwise. The breadcrumb needs the project key (from the issue key prefix) and the issue type (from `issue.issueType`) to build the scoped-resource URI hint.
+- `handleCreateIssue` / `handleUpdateIssue` / `handleMoveIssue` / `handleTransitionIssue` always pass `'breadcrumb'`... actually, pass an explicit `'none'` mode (no dump, no breadcrumb) — the `Applied:` section is the right read-out for a write.
+- No schema change needed (`custom_fields` is already a valid `expand` value).
+
+### Deferred (v2 — "depth dial")
+
+If the breadcrumb proves too coarse — agents almost always expand because they need *some* fields and the populated set is still large — escalate to a relevance-ranked reveal. The math is already half there:
+
+```
+score_for_reveal(field, issue) =
+    catalog.score(field)                    // ADR-201: screensCount × 10 + recency decay
+  + α × sessionInterest(field)              // new: touches in this process, decayed
+  + β × isPopulated(field, issue)           // per-issue boost
+```
+
+`sessionInterest` is a process-local `Map<fieldId, {touches, lastSeen}>` updated whenever a `get`/`update` references a field, decayed on the same half-life shape as the catalog's recency. It exists primarily for the unscored-mode case (ADR-213 §A1), where `catalog.score` is flat across all fields and `sessionInterest` becomes the only depth signal.
+
+`expand: ["custom_fields"]` then takes an optional depth — `expand: ["custom_fields:top"]` for top-N, `expand: ["custom_fields:populated"]` for the current opt-in set, `expand: ["custom_fields:empty"]` for the unset-but-settable set — but only if v1's breadcrumb measurement says the coarse default isn't enough. The simplest viable thing first; data drives the escalation.
+
+## Consequences
+
+### Positive
+
+- Routine `get` calls become token-light again; the cost of a populated dump moves to the call that explicitly asks for it.
+- Custom fields finally behave like every other rich section on `manage_jira_issue` — opt-in via `expand`.
+- The breadcrumb teaches the next move (the `expand` keyword and the scoped resource) instead of dumping and hoping the agent ignores it.
+- Post-write responses get smaller and more focused; `Applied:` is the read-out.
+
+### Negative
+
+- Any consumer that was parsing the Custom Fields block from a default `get` needs to add `expand: ["custom_fields"]`. (No known consumer does this — the populated-by-default behavior shipped in ADR-213 and the repo has had no time to grow dependents.)
+- One more concept for new callers to learn ("custom fields are an expand"), partially offset by it now matching the other expand options.
+
+### Neutral
+
+- The opt-in surface stays exactly as ADR-213 left it (`expand: ["custom_fields"]`); only the *default* changes. No schema migration.
+- The scoped resource `jira://custom-fields/{proj}/{type}` becomes the canonical "what could I set?" surface. Already exists; the breadcrumb just makes it discoverable.
+
+## Alternatives Considered
+
+- **Keep populated-by-default.** Rejected after live testing — the token cost is real, and the inconsistency with `comments`/`attachments`/`transitions`/`history` is glaring once seen. ADR-213's A2 decision was made before that evidence existed.
+- **Jump straight to the depth-dial / multi-mode expand** (`custom_fields_top` / `custom_fields_empty` / etc.) as v1. Rejected as premature: the breadcrumb might be enough, and `jira://custom-fields/{proj}/{type}` already serves the "what could I set?" use case. Build v1, measure, then escalate if needed.
+- **Trim the dump by limiting to N most-recent or N highest-scored.** Rejected as a half-measure: it's still always-on, still inconsistent with the other expand options, and the "N" is arbitrary.
+- **Render the breadcrumb on post-write too.** Rejected: `Applied:` is the right read-out for a write; the broader issue state isn't what the caller needs to see right after modifying it.

--- a/docs/architecture/tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md
+++ b/docs/architecture/tools/ADR-214-progressive-reveal-of-custom-fields-in-manage-jira-issue.md
@@ -1,5 +1,5 @@
 ---
-status: Draft
+status: Accepted
 date: 2026-05-11
 deciders:
   - aaronsb

--- a/src/docs/tool-documentation.ts
+++ b/src/docs/tool-documentation.ts
@@ -166,11 +166,14 @@ function generateIssueToolDocumentation(schema: any) {
       }
     ],
     custom_fields: {
-      description: "Custom fields are discovered automatically at startup. Use field names (not IDs) in the customFields parameter.",
-      discovery: "Read jira://custom-fields to see the master catalog of discovered fields with types and descriptions.",
-      context: "Read jira://custom-fields/{projectKey}/{issueType} to see fields valid for a specific project and issue type.",
-      name_resolution: "Field names are resolved to IDs automatically — use human-readable names like 'Story Points', not 'customfield_10035'.",
-      requirement: "Only fields with descriptions in Jira are discoverable. Fields without descriptions must use raw field IDs.",
+      description: "Custom fields are discovered automatically. Pass values in customFields as { name | customfield_NNNNN : value } — names are preferred.",
+      discovery: "Read jira://custom-fields for the master catalog of discovered fields with types and descriptions.",
+      context: "Read jira://custom-fields/{projectKey}/{issueType} for fields settable on a specific screen, with jsonSchema hints.",
+      capabilities: "Read jira://capabilities for the fieldRouting table — flags fields that need a dedicated tool or special handling. Examples: Sprint goes through manage_jira_sprint (operation: manage_issues); Epic Link / Parent Link / Parent go through the `parent` parameter on update, not customFields; Rank (backlog order) is not settable through this server; Tempo Account auto-resolves a name or numeric id via the project's account options.",
+      name_resolution: "Field names resolve to ids automatically — prefer 'Story Points' over 'customfield_10035'. Catalog lookup is case-insensitive.",
+      clear_semantics: "Pass null to clear a field. Empty string ('') may collide with name-resolution on extension-routed fields (e.g., Tempo Account: '' matches all account names ambiguously) — null is the safe path.",
+      view_after_write: "Populated custom fields are NOT rendered on `get` by default — a one-line breadcrumb names the count and the opt-in. Pass `expand: [\"custom_fields\"]` to render the full block. Post-write renders drop the block entirely; the `Applied:` section is the read-out.",
+      requirement: "Only fields with descriptions in Jira are discoverable. Fields without descriptions must be referenced by raw customfield_NNNNN id.",
     },
     related_resources: [
       { name: "Project Overview", uri: "jira://projects/{projectKey}/overview", description: "Get detailed information about a project" },

--- a/src/handlers/issue-handlers.ts
+++ b/src/handlers/issue-handlers.ts
@@ -451,8 +451,14 @@ async function handleGetIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs)
     transitions = await jiraClient.getTransitions(args.issueKey!);
   }
   
-  // Render to markdown
-  const markdown = MarkdownRenderer.renderIssue(issue, transitions);
+  // Render to markdown — ADR-214: minimal-by-default custom-field reveal.
+  // `expand: ["custom_fields"]` opts into the full dump; otherwise emit a one-line breadcrumb
+  // pointing at the opt-in and the scoped `jira://custom-fields/{proj}/{type}` resource.
+  const markdown = MarkdownRenderer.renderIssue(issue, transitions, {
+    customFields: includeAllCustomFields ? 'dump' : 'breadcrumb',
+    projectKey: args.issueKey!.split('-')[0],
+    issueTypeName: issue.issueType,
+  });
 
   return {
     content: [
@@ -478,7 +484,8 @@ async function handleMoveIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs
 
   // Get the moved issue (it now has a new key in the target project)
   const movedIssue = await jiraClient.getIssue(issueKey, false, false, getCatalogFieldMeta());
-  const markdown = MarkdownRenderer.renderIssue(movedIssue);
+  // ADR-214: post-write — `Applied:` is the read-out; drop the custom-fields block entirely.
+  const markdown = MarkdownRenderer.renderIssue(movedIssue, undefined, { customFields: 'none' });
 
   return {
     content: [
@@ -501,7 +508,9 @@ async function handleDeleteIssue(jiraClient: JiraClient, args: ManageJiraIssueAr
 
   // Get the issue details before deleting for a final snapshot
   const issue = await jiraClient.getIssue(issueKey, false, false);
-  const markdown = MarkdownRenderer.renderIssue(issue);
+  // ADR-214: post-write — the dump is noise on a soon-to-be-deleted issue, and the breadcrumb
+  // would point at expand/resource URIs that no longer apply once the delete lands.
+  const markdown = MarkdownRenderer.renderIssue(issue, undefined, { customFields: 'none' });
 
   await jiraClient.deleteIssue(issueKey);
   bulkOperationGuard.record('delete', issueKey);
@@ -541,7 +550,8 @@ async function handleCreateIssue(jiraClient: JiraClient, args: ManageJiraIssueAr
   
   // Get the created issue and render to markdown
   const createdIssue = await jiraClient.getIssue(result.key, false, false, getCatalogFieldMeta(), false, !!args.customFields);
-  const markdown = MarkdownRenderer.renderIssue(createdIssue);
+  // ADR-214: post-write — `Applied:` is the read-out; drop the custom-fields block entirely.
+  const markdown = MarkdownRenderer.renderIssue(createdIssue, undefined, { customFields: 'none' });
   const applied = renderAppliedFields(args, createdIssue);
 
   return {
@@ -583,7 +593,8 @@ async function handleUpdateIssue(jiraClient: JiraClient, args: ManageJiraIssueAr
 
   // Get the updated issue and render to markdown
   const updatedIssue = await jiraClient.getIssue(args.issueKey!, false, false, getCatalogFieldMeta(), false, !!args.customFields);
-  const markdown = MarkdownRenderer.renderIssue(updatedIssue);
+  // ADR-214: post-write — `Applied:` is the read-out; drop the custom-fields block entirely.
+  const markdown = MarkdownRenderer.renderIssue(updatedIssue, undefined, { customFields: 'none' });
   const applied = renderAppliedFields(args, updatedIssue);
 
   return {
@@ -605,7 +616,9 @@ async function handleTransitionIssue(jiraClient: JiraClient, args: ManageJiraIss
 
   // Get the updated issue and render to markdown
   const updatedIssue = await jiraClient.getIssue(args.issueKey!, false, false, getCatalogFieldMeta());
-  const markdown = MarkdownRenderer.renderIssue(updatedIssue);
+  // ADR-214: post-write — transition has no `Applied:` section, but the custom-fields dump still
+  // adds ~600 tokens of noise unrelated to the state change. Drop it.
+  const markdown = MarkdownRenderer.renderIssue(updatedIssue, undefined, { customFields: 'none' });
 
   return {
     content: [
@@ -622,7 +635,8 @@ async function handleCommentIssue(jiraClient: JiraClient, args: ManageJiraIssueA
 
   // Get the updated issue with comments and render to markdown
   const updatedIssue = await jiraClient.getIssue(args.issueKey!, true, false);
-  const markdown = MarkdownRenderer.renderIssue(updatedIssue);
+  // ADR-214: post-write — the new comment is the read-out; custom-field block is noise.
+  const markdown = MarkdownRenderer.renderIssue(updatedIssue, undefined, { customFields: 'none' });
 
   return {
     content: [
@@ -647,7 +661,8 @@ async function handleLinkIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs
 
   // Get the updated issue and render to markdown
   const updatedIssue = await jiraClient.getIssue(args.issueKey!, false, false);
-  const markdown = MarkdownRenderer.renderIssue(updatedIssue);
+  // ADR-214: post-write — the new link is the read-out; custom-field block is noise.
+  const markdown = MarkdownRenderer.renderIssue(updatedIssue, undefined, { customFields: 'none' });
 
   return {
     content: [
@@ -672,7 +687,8 @@ async function handleWorklogIssue(jiraClient: JiraClient, args: ManageJiraIssueA
 
   // Get the updated issue and render to markdown
   const updatedIssue = await jiraClient.getIssue(args.issueKey!, false, false);
-  const markdown = MarkdownRenderer.renderIssue(updatedIssue);
+  // ADR-214: post-write — the logged worklog is the read-out; custom-field block is noise.
+  const markdown = MarkdownRenderer.renderIssue(updatedIssue, undefined, { customFields: 'none' });
 
   return {
     content: [

--- a/src/mcp/markdown-renderer.test.ts
+++ b/src/mcp/markdown-renderer.test.ts
@@ -66,7 +66,7 @@ describe('renderIssue — custom field reveal modes (ADR-214)', () => {
     expect(out).not.toContain('Tempo Account (option)');
   });
 
-  it('breadcrumb: omits the URI clause when projectKey/issueTypeName are absent', () => {
+  it('breadcrumb: omits the URI clause when both projectKey and issueTypeName are absent', () => {
     const out = renderIssue(
       makeIssue({ customFieldValues: POPULATED_THREE }),
       undefined,
@@ -75,6 +75,34 @@ describe('renderIssue — custom field reveal modes (ADR-214)', () => {
     expect(out).toContain('3 populated custom fields not shown');
     expect(out).toContain('`expand: ["custom_fields"]`');
     expect(out).not.toContain('jira://custom-fields/');
+  });
+
+  it('breadcrumb: omits the URI clause when only projectKey is present', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'breadcrumb', projectKey: 'PAID' },
+    );
+    expect(out).not.toContain('jira://custom-fields/');
+  });
+
+  it('breadcrumb: omits the URI clause when only issueTypeName is present', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'breadcrumb', issueTypeName: 'Task' },
+    );
+    expect(out).not.toContain('jira://custom-fields/');
+  });
+
+  it('breadcrumb: URL-encodes issueTypeName so multi-word types round-trip through the resource resolver', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'breadcrumb', projectKey: 'PAID', issueTypeName: 'User Story' },
+    );
+    expect(out).toContain('`jira://custom-fields/PAID/User%20Story`');
+    expect(out).not.toContain('PAID/User Story`');
   });
 
   it('breadcrumb: singular phrasing when exactly one field is populated', () => {

--- a/src/mcp/markdown-renderer.test.ts
+++ b/src/mcp/markdown-renderer.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { renderIssue } from './markdown-renderer.js';
+import type { JiraIssueDetails } from '../types/index.js';
+
+// Minimal fixture builder — keeps test rows readable while satisfying the type's required fields.
+function makeIssue(overrides: Partial<JiraIssueDetails> = {}): JiraIssueDetails {
+  return {
+    key: 'PAID-192',
+    summary: 'Safe to delete',
+    description: '',
+    issueType: 'Task',
+    priority: null,
+    parent: null,
+    assignee: null,
+    reporter: 'someone',
+    status: 'To Do',
+    statusCategory: 'new',
+    resolution: null,
+    labels: [],
+    created: '2026-05-01T00:00:00.000Z',
+    updated: '2026-05-01T00:00:00.000Z',
+    resolutionDate: null,
+    statusCategoryChanged: null,
+    dueDate: null,
+    startDate: null,
+    storyPoints: null,
+    timeEstimate: null,
+    originalEstimate: null,
+    timeSpent: null,
+    sprint: null,
+    issueLinks: [],
+    ...overrides,
+  };
+}
+
+const POPULATED_THREE = [
+  { name: 'Tempo Account', value: 'Internal Ops', type: 'option', description: '' },
+  { name: 'Acceptance Criteria', value: 'All checks pass', type: 'string', description: '' },
+  { name: 'Sprint Goal', value: ['Goal A', 'Goal B'], type: 'array', description: '' },
+];
+
+describe('renderIssue — custom field reveal modes (ADR-214)', () => {
+  it('dump: renders the full Custom Fields block', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'dump' },
+    );
+    expect(out).toContain('Custom Fields:');
+    expect(out).toContain('Tempo Account (option): Internal Ops');
+    expect(out).toContain('Acceptance Criteria (string): All checks pass');
+    expect(out).toContain('Sprint Goal (array): Goal A, Goal B');
+    expect(out).not.toContain('not shown');
+  });
+
+  it('breadcrumb (default): one-line hint with count + expand + scoped URI', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'breadcrumb', projectKey: 'PAID', issueTypeName: 'Task' },
+    );
+    expect(out).toContain('3 populated custom fields not shown');
+    expect(out).toContain('`expand: ["custom_fields"]`');
+    expect(out).toContain('`jira://custom-fields/PAID/Task`');
+    expect(out).not.toContain('Custom Fields:');
+    expect(out).not.toContain('Tempo Account (option)');
+  });
+
+  it('breadcrumb: omits the URI clause when projectKey/issueTypeName are absent', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'breadcrumb' },
+    );
+    expect(out).toContain('3 populated custom fields not shown');
+    expect(out).toContain('`expand: ["custom_fields"]`');
+    expect(out).not.toContain('jira://custom-fields/');
+  });
+
+  it('breadcrumb: singular phrasing when exactly one field is populated', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE.slice(0, 1) }),
+      undefined,
+      { customFields: 'breadcrumb' },
+    );
+    expect(out).toContain('1 populated custom field not shown');
+  });
+
+  it('none: renders neither the block nor the breadcrumb', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+      undefined,
+      { customFields: 'none' },
+    );
+    expect(out).not.toContain('Custom Fields:');
+    expect(out).not.toContain('not shown');
+    expect(out).not.toContain('Tempo Account');
+  });
+
+  it('default (no opts): treats as breadcrumb', () => {
+    const out = renderIssue(
+      makeIssue({ customFieldValues: POPULATED_THREE }),
+    );
+    expect(out).toContain('not shown');
+    expect(out).not.toContain('Custom Fields:');
+  });
+
+  describe('zero populated → silent in every mode', () => {
+    it.each(['dump', 'breadcrumb', 'none'] as const)('%s mode is silent', (mode) => {
+      const out = renderIssue(
+        makeIssue({ customFieldValues: [] }),
+        undefined,
+        { customFields: mode, projectKey: 'PAID', issueTypeName: 'Task' },
+      );
+      expect(out).not.toContain('Custom Fields:');
+      expect(out).not.toContain('not shown');
+    });
+
+    it('undefined customFieldValues is silent', () => {
+      const out = renderIssue(makeIssue(), undefined, { customFields: 'breadcrumb' });
+      expect(out).not.toContain('not shown');
+    });
+  });
+});

--- a/src/mcp/markdown-renderer.ts
+++ b/src/mcp/markdown-renderer.ts
@@ -199,8 +199,11 @@ export function renderIssue(
     }
   } else if (customFieldsMode === 'breadcrumb' && populatedCount > 0) {
     lines.push('');
+    // Issue-type names can contain spaces ("User Story", "Service Request") — the catalog
+    // resource emitter encodes the type and the resolver decodes it (resource-handlers.ts:148, 533),
+    // so the breadcrumb URI has to encode too or the link round-trips wrong.
     const uri = opts.projectKey && opts.issueTypeName
-      ? ` For what's settable on this issue type: read \`jira://custom-fields/${opts.projectKey}/${opts.issueTypeName}\`.`
+      ? ` For what's settable on this issue type: read \`jira://custom-fields/${opts.projectKey}/${encodeURIComponent(opts.issueTypeName)}\`.`
       : '';
     lines.push(
       `📋 ${populatedCount} populated custom field${populatedCount === 1 ? '' : 's'} not shown. ` +

--- a/src/mcp/markdown-renderer.ts
+++ b/src/mcp/markdown-renderer.ts
@@ -96,9 +96,26 @@ function stripHtml(html: string): string {
 // ============================================================================
 
 /**
+ * How to render the populated-custom-fields section on an issue (ADR-214).
+ * - `dump`: print the full `Custom Fields:` block (the pre-ADR-214 behaviour).
+ * - `breadcrumb` (default for `get`): one-line hint pointing at `expand: ["custom_fields"]`
+ *   and the scoped `jira://custom-fields/{proj}/{type}` resource. Silent if zero are populated.
+ * - `none`: render nothing — used after writes where the `Applied:` section is the read-out.
+ */
+export interface RenderIssueOptions {
+  customFields?: 'breadcrumb' | 'dump' | 'none';
+  projectKey?: string;
+  issueTypeName?: string;
+}
+
+/**
  * Render a single issue as markdown
  */
-export function renderIssue(issue: JiraIssueDetails, transitions?: TransitionDetails[]): string {
+export function renderIssue(
+  issue: JiraIssueDetails,
+  transitions?: TransitionDetails[],
+  opts: RenderIssueOptions = {},
+): string {
   const lines: string[] = [];
 
   lines.push(`# ${issue.key}: ${issue.summary}`);
@@ -166,16 +183,29 @@ export function renderIssue(issue: JiraIssueDetails, transitions?: TransitionDet
     }
   }
 
-  // Custom fields (from catalog discovery)
-  if (issue.customFieldValues && issue.customFieldValues.length > 0) {
+  // Custom fields — progressive reveal (ADR-214). Default is a breadcrumb pointing at the
+  // opt-in expand and the scoped resource; the full dump is gated behind `customFields: 'dump'`.
+  // Zero populated → silent in every mode.
+  const customFieldsMode = opts.customFields ?? 'breadcrumb';
+  const populatedCount = issue.customFieldValues?.length ?? 0;
+  if (customFieldsMode === 'dump' && populatedCount > 0) {
     lines.push('');
     lines.push('Custom Fields:');
-    for (const cf of issue.customFieldValues) {
+    for (const cf of issue.customFieldValues!) {
       const displayValue = Array.isArray(cf.value)
         ? (cf.value as unknown[]).join(', ')
         : String(cf.value);
       lines.push(`${cf.name} (${cf.type}): ${displayValue}`);
     }
+  } else if (customFieldsMode === 'breadcrumb' && populatedCount > 0) {
+    lines.push('');
+    const uri = opts.projectKey && opts.issueTypeName
+      ? ` For what's settable on this issue type: read \`jira://custom-fields/${opts.projectKey}/${opts.issueTypeName}\`.`
+      : '';
+    lines.push(
+      `📋 ${populatedCount} populated custom field${populatedCount === 1 ? '' : 's'} not shown. ` +
+      `To view: \`expand: ["custom_fields"]\`.${uri}`,
+    );
   }
 
   // Status history (if requested via expand: ["history"])

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -144,7 +144,7 @@ export const toolSchemas = {
 
   manage_jira_issue: {
     name: 'manage_jira_issue',
-    description: 'Get, create, update, delete, move, transition, comment on, link, log work on, or explore hierarchy of Jira issues',
+    description: 'Get, create, update, delete, move, transition, comment on, link, log work on, or explore hierarchy of Jira issues. For custom-field writes, consult `jira://capabilities` (field routing) and `jira://custom-fields/{projectKey}/{issueType}` (what is settable here) — some fields need dedicated tools and others auto-resolve names to ids.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -188,7 +188,7 @@ export const toolSchemas = {
         },
         customFields: {
           type: 'object',
-          description: 'Custom field values as key-value pairs.',
+          description: 'Custom field values as { name | id : value }. Names auto-resolve to customfield_NNNNN. Read `jira://capabilities` for the field-routing table (which fields need a dedicated tool or have value-resolution) and `jira://custom-fields/{projectKey}/{issueType}` for what is settable on a given screen, with types and clearing semantics.',
         },
         dueDate: {
           type: ['string', 'null'],

--- a/src/schemas/tool-schemas.ts
+++ b/src/schemas/tool-schemas.ts
@@ -269,7 +269,7 @@ export const toolSchemas = {
             type: 'string',
             enum: ['comments', 'transitions', 'attachments', 'related_issues', 'history', 'custom_fields'],
           },
-          description: 'Additional fields to include in the response. Populated custom fields are returned by default once the field catalog is ready; pass "custom_fields" to also surface populated custom fields that fall outside the curated catalog (the full set of fields on the issue).',
+          description: 'Additional fields to include in the response. Populated custom fields are NOT shown by default — `get` emits a one-line breadcrumb with the count and the opt-in. Pass "custom_fields" to render the full populated dump. For what is *settable* on this issue type (with usage hints), read the scoped resource `jira://custom-fields/{projectKey}/{issueType}` instead.',
         },
       },
       required: ['operation'],


### PR DESCRIPTION
## Summary

Reverses ADR-213 §A2's "render populated custom fields by default" decision after live evidence that it costs ~600 tokens per `get` on PAID issues (35–40 populated of 498 catalog fields). Custom fields are now opt-in, consistent with `comments` / `transitions` / `attachments` / `history`.

- **Default `get`** → emits a one-line breadcrumb pointing at the opt-in and the scoped resource. No `Custom Fields:` block.
- **`get` with `expand: ["custom_fields"]`** → renders the full populated dump (the pre-ADR-214 behaviour).
- **All write/mutation operations** (`create` / `update` / `move` / `transition` / `delete` / `comment` / `link` / `worklog`) → drop the custom-fields block entirely. The `Applied:` section (for create/update) or the operation's own change-of-state is the read-out; the dump is noise unrelated to what changed.
- **Zero populated** → silent in every mode.

ADR-214 captures the rationale, the v1 scope, and the deferred v2 (depth-dial / `sessionInterest`) sketch.

## Agent-facing routing docs (follow-up commit, d0dd16e)

Live verification of the Tempo Account flow surfaced that without prior context an agent would have to discover field routing by failing writes — the `jira://capabilities` resource has had this info since ADR-213 §B, but the agent-facing tool surfaces didn't point at it. Three surfaces updated:

- `customFields` parameter description (`tool-schemas.ts:189-192`) — was a one-liner; now names the two canonical resources (`jira://capabilities` for routing, `jira://custom-fields/{proj}/{type}` for what's settable) and notes that names auto-resolve. Tight on purpose: the resources carry the detail.
- `manage_jira_issue` top-level description — appends one sentence about consulting those resources, since some fields need dedicated tools (Sprint, Parent) and others auto-resolve (Tempo Account).
- `custom_fields` block in `jira://tools/manage_jira_issue/documentation` — adds `capabilities`, `clear_semantics`, and `view_after_write` keys with the routing examples, null-vs-empty-string clear semantics, and ADR-214's get-default behaviour.

## Files

- `src/mcp/markdown-renderer.ts` — added `RenderIssueOptions`; modes `'breadcrumb'` (default) / `'dump'` / `'none'`.
- `src/handlers/issue-handlers.ts` — wired modes per operation (see Summary).
- `src/schemas/tool-schemas.ts` — rewrote the `expand` description; refined `customFields` and top-level `manage_jira_issue` descriptions.
- `src/mcp/markdown-renderer.test.ts` — new file, 10 tests covering all three modes, singular/plural phrasing, missing-context fallback, zero-population silence.
- `src/docs/tool-documentation.ts` — expanded the `custom_fields` documentation block.
- `docs/architecture/tools/ADR-214-…md` — Draft → Accepted post-verification.
- `docs/architecture/INDEX.md` — regenerated.

## Note: scope of `'none'` widened from the implementation plan

The plan listed `create / update / move / transition` for `'none'`. I extended it to `delete / comment / link / worklog` too — the stated principle ("post-write drops the dump; `Applied:` is the read-out") applies uniformly, and a breadcrumb on a soon-to-be-deleted issue pointing at `expand: ["custom_fields"]` / `jira://custom-fields/...` is actively wrong because those URIs no longer apply once the delete lands. Flagged in the commit message.

## Test plan

Local: `npm run build && npx vitest run && npm run lint` — 0 errors, 436/436 tests pass (10 new), 0 lint errors (5 pre-existing warnings in unrelated files).

Live verification post-`/mcp reload` against PAID (non-admin connection, catalog in unscored mode, 498 fields, 39 populated on PAID-192):

- [x] `manage_jira_issue get PAID-192` → ends with breadcrumb `📋 39 populated custom fields not shown. To view: \`expand: ["custom_fields"]\`. For what's settable on this issue type: read \`jira://custom-fields/PAID/Task\`.`; no `Custom Fields:` block.
- [x] `manage_jira_issue get PAID-192 expand: ["custom_fields"]` → full populated `Custom Fields:` block renders (RSVP Required, Payment Reference, … 39 lines).
- [x] `manage_jira_issue update PAID-192 labels: ["adr214-check"]` → `**Applied:** - **Labels**: adr214-check`; no `Custom Fields:` block, no breadcrumb. Cleared with `labels: []` → `**Applied:** - **Labels**: (none)`.
- [x] `manage_jira_issue update PAID-192 customFields: {"Account": "OpEx - Praecipio AI Dev"}` (Tempo flow regression check) → `**Applied:** - **Account**: OpEx - Praecipio AI Dev`; populated count on next `get` jumps 39 → 40; Account visible inside the `expand: ["custom_fields"]` dump; `null` clears cleanly.
- [x] `jira://capabilities` → unchanged from ADR-213 (unscored mode, 498 fields, extensions + fieldRouting intact).

## Deferred

V2 — depth-dial / multi-mode expand (`custom_fields:top`, `:empty`, etc.), `sessionInterest` map, per-process field-touch tracking — is sketched in ADR-214's Decision section and explicitly out of scope here.

## Related

- Supersedes the default established by ADR-213 §A2 (keeps that ADR's trail intact — it documents a decision that was right at the time and superseded by live evidence).
- PR #51 (ADR-212 — tool surface consolidation) is still open; if it merges first, `docs/architecture/INDEX.md` will need a trivial conflict resolve here.