### PR TITLE
chore: PR #54 review followups — projectKey helper + drop ! assertion

### DIFF
--- a/src/handlers/issue-handlers.ts
+++ b/src/handlers/issue-handlers.ts
@@ -421,6 +421,12 @@ function issueGuidance(operation: string, issueKey?: string): string {
   return issueNextSteps(operation, issueKey) + getUndescribedFieldNag();
 }
 
+/** Extract the project key prefix from a Jira issue key (e.g. `PROJ-123` → `PROJ`).
+ *  Uppercases the result so handlers don't drift from each other on casing. */
+function projectKeyFromIssueKey(issueKey: string): string {
+  return issueKey.split('-')[0].toUpperCase();
+}
+
 // Handler functions for each operation
 async function handleGetIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs) {
   // Parse expansion options
@@ -456,7 +462,7 @@ async function handleGetIssue(jiraClient: JiraClient, args: ManageJiraIssueArgs)
   // pointing at the opt-in and the scoped `jira://custom-fields/{proj}/{type}` resource.
   const markdown = MarkdownRenderer.renderIssue(issue, transitions, {
     customFields: includeAllCustomFields ? 'dump' : 'breadcrumb',
-    projectKey: args.issueKey!.split('-')[0],
+    projectKey: projectKeyFromIssueKey(args.issueKey!),
     issueTypeName: issue.issueType,
   });
 
@@ -569,7 +575,7 @@ async function handleUpdateIssue(jiraClient: JiraClient, args: ManageJiraIssueAr
   if (customFields && customFieldsNeedRouting(customFields)) {
     // createmeta-based resolution needs the issue's type; the project key is the key prefix.
     const probe = await jiraClient.getIssue(args.issueKey!, false, false);
-    const projectKey = args.issueKey!.split('-')[0].toUpperCase();
+    const projectKey = projectKeyFromIssueKey(args.issueKey!);
     try {
       customFields = await applyRouteResolutions(jiraClient, customFields, projectKey, probe.issueType);
     } catch (e) {

--- a/src/mcp/markdown-renderer.ts
+++ b/src/mcp/markdown-renderer.ts
@@ -187,11 +187,12 @@ export function renderIssue(
   // opt-in expand and the scoped resource; the full dump is gated behind `customFields: 'dump'`.
   // Zero populated → silent in every mode.
   const customFieldsMode = opts.customFields ?? 'breadcrumb';
-  const populatedCount = issue.customFieldValues?.length ?? 0;
+  const cfs = issue.customFieldValues ?? [];
+  const populatedCount = cfs.length;
   if (customFieldsMode === 'dump' && populatedCount > 0) {
     lines.push('');
     lines.push('Custom Fields:');
-    for (const cf of issue.customFieldValues!) {
+    for (const cf of cfs) {
       const displayValue = Array.isArray(cf.value)
         ? (cf.value as unknown[]).join(', ')
         : String(cf.value);


### PR DESCRIPTION
## Summary

Picks up the two non-blocking items that landed deferred on #54 (https://github.com/aaronsb/jira-cloud/pull/54#issuecomment-4425677154):

- **markdown-renderer.ts** — hoist `const cfs = issue.customFieldValues ?? []` once at the top of the custom-fields section; derive `populatedCount` from `cfs.length` and iterate `cfs` in the dump branch. Drops the `!` non-null assertion that the previous shape needed because narrowing didn't carry through the derived `populatedCount` const.
- **issue-handlers.ts** — extract `projectKeyFromIssueKey(issueKey)` and use it at both call sites (`handleGetIssue:459`, `handleUpdateIssue:572`). Side benefit caught during the extraction: the two sites had drifted on casing — `handleGetIssue` was missing the `.toUpperCase()` that `handleUpdateIssue` applied. The helper unifies them so the two handlers can't disagree on what `paid-192 → ?` means. In practice Jira issue keys are always uppercase, so this is normalization rather than a fix for an observed bug.

No behaviour change for any realistic input (uppercased issue keys, populated or empty `customFieldValues`).

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npx vitest run` — 439/439 pass (no test changes; the suite already covers both the dump branch and the projectKey-in-breadcrumb path)
- [x] `npm run lint` — 0 errors (5 pre-existing warnings in unrelated files)