### PR TITLE
fix: catalog writable flag matches extension write path (Tempo Account)

### DIFF
--- a/src/client/field-discovery.test.ts
+++ b/src/client/field-discovery.test.ts
@@ -260,6 +260,33 @@ describe('FieldDiscovery', () => {
     expect(catalog[0].screensCount).toBe(0);
   });
 
+  it('marks an extension-handled field writable even when its Jira type is unsupported (Tempo Account)', async () => {
+    const client = {
+      issueFields: {
+        getFieldsPaginated: async () => { throw new Error('Request failed with status code 403'); },
+        getFields: async () => [
+          // Opaque schema → the classifier can't map it (`unsupported`). Named "Account" so the
+          // Tempo extension route claims it and `resolveTempoAccountWrite` makes it writable.
+          { id: 'customfield_11266', name: 'Account', custom: true, schema: { type: 'any', custom: 'io.tempo.jira__account' } },
+          // Same opaque shape, but no extension route owns it → stays conservatively read-only.
+          { id: 'customfield_99999', name: 'Mystery Widget', custom: true, schema: { type: 'any', custom: 'com.acme:widget' } },
+        ],
+      },
+    } as any;
+
+    await discovery.discover(client);
+    expect(discovery.getState()).toBe('unscored');
+
+    const catalog = discovery.getCatalog();
+    const account = catalog.find(f => f.id === 'customfield_11266')!;
+    const mystery = catalog.find(f => f.id === 'customfield_99999')!;
+    // The classifier still can't produce a JSON schema for either — but the Tempo route can write Account.
+    expect(account.category).toBe('unsupported');
+    expect(account.writable).toBe(true);
+    expect(mystery.category).toBe('unsupported');
+    expect(mystery.writable).toBe(false);
+  });
+
   it('handles empty field list', async () => {
     const client = createMockClient([]);
     await discovery.discover(client);

--- a/src/client/field-discovery.test.ts
+++ b/src/client/field-discovery.test.ts
@@ -287,6 +287,25 @@ describe('FieldDiscovery', () => {
     expect(mystery.writable).toBe(false);
   });
 
+  it('matches an extension route by schema-custom key when the field name was renamed', async () => {
+    // A Forge-style Tempo Account field that a tenant admin renamed away from "Account" — the route
+    // no longer matches on name, but `io.tempo.jira__account` is also one of the route's claimed keys,
+    // so `extensionCanWrite` falls back to matching on `schema.custom`.
+    const client = {
+      issueFields: {
+        getFieldsPaginated: async () => { throw new Error('Request failed with status code 403'); },
+        getFields: async () => [
+          { id: 'customfield_11266', name: 'Billing Bucket', custom: true, schema: { type: 'any', custom: 'io.tempo.jira__account' } },
+        ],
+      },
+    } as any;
+
+    await discovery.discover(client);
+    const billing = discovery.getCatalog().find(f => f.id === 'customfield_11266')!;
+    expect(billing.category).toBe('unsupported');
+    expect(billing.writable).toBe(true);
+  });
+
   it('handles empty field list', async () => {
     const client = createMockClient([]);
     await discovery.discover(client);

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -9,6 +9,7 @@
 import { Version3Client } from 'jira.js';
 
 import { classifyFieldType, type FieldCategory, type FieldTypeInfo } from './field-type-map.js';
+import { routeForField } from '../extensions/index.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -79,6 +80,19 @@ const RECENCY_WEIGHT = 5;
 const RECENCY_HALF_LIFE_DAYS = 30;
 
 // ── Field Discovery ────────────────────────────────────────────────────
+
+/**
+ * True if an extension route owns a value-resolving write handler for this field (ADR-213 §B).
+ * Used to mark `writable: true` on a field whose Jira type our classifier can't map — e.g. Tempo
+ * Account reports an opaque schema (→ `unsupported` category) but `resolveTempoAccountWrite` turns
+ * a name into the numeric id the standard issue-edit endpoint accepts. Matches the route by field
+ * name first, then by schema-custom key. (#45 follow-up: keeps the catalog `writable` flag in
+ * step with what the write path actually does.)
+ */
+function extensionCanWrite(fieldName: string, schemaCustom: string): boolean {
+  const route = routeForField(fieldName) ?? (schemaCustom ? routeForField(schemaCustom) : undefined);
+  return route?.resolveWrite != null;
+}
 
 /** Well-known locked fields identified by schema custom type */
 const WELL_KNOWN_FIELDS: Record<string, string> = {
@@ -533,7 +547,7 @@ export class FieldDiscovery {
           name: f.name,
           description: f.description,
           category: typeInfo.category,
-          writable: typeInfo.writable,
+          writable: typeInfo.writable || extensionCanWrite(f.name, f.schemaCustom),
           jsonSchema: typeInfo.jsonSchema,
           schemaCustom: f.schemaCustom,
           screensCount: 0,

--- a/src/client/field-discovery.ts
+++ b/src/client/field-discovery.ts
@@ -600,6 +600,10 @@ export class FieldDiscovery {
       }
 
       // Filter: supported type
+      // NOTE: this also drops extension-handled fields whose Jira type our classifier can't map
+      // (e.g. Tempo Account on an admin tenant) — the unscored fallback keeps them and flags them
+      // writable via `extensionCanWrite`, but the scored path doesn't. Retaining them here is a
+      // larger change (it shifts what's in the curated catalog, not just a flag). See #45 / #57.
       const typeInfo = classifyFieldType(field.schemaType, field.schemaCustom || undefined, field.schemaItems || undefined);
       if (typeInfo.category === 'unsupported') {
         excludedUnsupportedType++;


### PR DESCRIPTION
## Summary

Follow-up to #45, surfaced in the post-fix report on the Tempo Account flow. The catalog's `writable` flag and the actual write path disagreed for extension-handled fields.

`buildUnscoredCatalog` set `writable` straight from `classifyFieldType`. Tempo Account reports an opaque Jira schema our classifier can't map → `category: 'unsupported'` → `writable: false`. But the Tempo extension route's `resolveTempoAccountWrite` turns a name into the numeric id the standard issue-edit endpoint accepts, and a write **succeeds** (verified live last session: `update PAID-192 customFields: {"Account": "OpEx - Praecipio AI Dev"}` → `Applied: Account: OpEx - Praecipio AI Dev`). So the catalog told an agent "not writable" about a field it could write.

## Fix

After classification, if an extension route owns a value-resolving write handler for the field — matched by field name, then by schema-custom key — mark `writable: true`. `category` stays `'unsupported'`: that label accurately means "no generic JSON-schema mapping", which is still true; `writable` is the actionable flag and now reflects what the write path does. A small free function `extensionCanWrite(fieldName, schemaCustom)` encapsulates the check.

```ts
writable: typeInfo.writable || extensionCanWrite(f.name, f.schemaCustom),
```

Pulls in `routeForField` from `../extensions/index.js`. That introduces an import edge `field-discovery → extensions/index → tempo → field-discovery`; it's ESM-safe (tempo.ts only references `fieldDiscovery` inside function bodies, never at module-eval time) and `extensions/index.ts` is designed as the composition point other modules query.

## Scope / known limitation

Only the **unscored** (non-admin, 403-fallback) catalog is touched. In scored mode, `unsupported`-typed fields are excluded from the curated catalog entirely (`field-discovery.ts:590`), so an admin tenant never sees Tempo Account in the curated list to begin with. Keeping extension-handled fields in the scored catalog despite an unmappable type is a bigger change and a separate decision — not in this PR. Worth a note on #45 / #45's siblings if anyone cares; the non-admin path is the one the reporter hit.

## Test plan

- [x] `npm run build` — 0 errors (the cross-module import compiles and runs)
- [x] `npx vitest run` — 440/440 (1 new in `field-discovery.test.ts`: opaque-schema field named "Account" → `writable: true`; opaque field with no extension route → `writable: false`)
- [x] `npm run lint` — 0 errors (5 pre-existing warnings, unrelated files)
- [ ] Live: after merge + main rebuild + `/mcp reload`, `jira://custom-fields` should show `customfield_11266` (Account) with `writable: true`. Couldn't self-verify — background session's MCP server runs the pre-merge build.